### PR TITLE
78-feature_request-add-average-grade

### DIFF
--- a/custom_components/homeassistantedupage/manifest.json
+++ b/custom_components/homeassistantedupage/manifest.json
@@ -7,6 +7,6 @@
     "documentation": "https://github.com/rine77/homeassistantedupage",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/rine77/homeassistantedupage/issues",
-    "requirements": ["edupage-api==0.12.1", "unidecode"],
+    "requirements": ["edupage-api==0.12.2", "unidecode"],
     "version": "0.3.4"
 }

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -101,6 +101,8 @@ class EduPageSubjectSensor(CoordinatorEntity, SensorEntity):
             attributes[f"grade_{i+1}_grade_n"] = grade.grade_n
             if grade.max_points:
                 attributes[f"grade_{i+1}_max_points"] = grade.max_points
+            if grade.class_grade_avg:
+                attributes[f"grade_{i+1}_class_avg_grade"] = grade.class_grade_avg
             if grade.percent:
                 attributes[f"grade_{i+1}_percent"] = grade.percent
             if grade.comment:


### PR DESCRIPTION
Include the average grade in the extra state attributes if it is available. Update the requirements to use a newer version of the edupage-api.