### PR TITLE
Fall back to fresh login when session reload crashes (fixes #70)

### DIFF
--- a/custom_components/homeassistantedupage/homeassistant_edupage.py
+++ b/custom_components/homeassistantedupage/homeassistant_edupage.py
@@ -18,9 +18,17 @@ class Edupage:
         try:
             result = True
             login = Login(self.api)
-            await self.hass.async_add_executor_job(
-                login.reload_data, subdomain, self.sessionid, username
-            )
+            try:
+                await self.hass.async_add_executor_job(
+                    login.reload_data, subdomain, self.sessionid, username
+                )
+            except Exception as reload_err:
+                _LOGGER.warning(
+                    "EDUPAGE session reload failed (%s), falling back to fresh login",
+                    reload_err,
+                )
+                # Recreate API instance — reload_data may have polluted internal state
+                self.api = APIEdupage()
             if not self.api.is_logged_in:
                 #TODO: how to handle 2FA at this point?!
                 result = await self.hass.async_add_executor_job(


### PR DESCRIPTION
## Problem

Closes #70.

When the stored `PHPSESSID` expires, `Login.reload_data` in `edupage-api` raises an exception (most commonly `list index out of range` — happens whenever EduPage tweaks the login HTML structure). The current code in `homeassistant_edupage.py` is structured so this exception goes straight to the catch-all `except Exception` handler:

```python
result = True
login = Login(self.api)
await self.hass.async_add_executor_job(
    login.reload_data, subdomain, self.sessionid, username
)
if not self.api.is_logged_in:
    # fallback never reached if reload_data raised
    result = await self.hass.async_add_executor_job(
        self.api.login, username, password, subdomain
    )
```

The intended fresh-login fallback (`self.api.login(username, password, subdomain)`) is **never** reached, so the integration stays in a permanently-broken state until the user deletes and re-adds it.

## Fix

Wrap `reload_data` in its own `try/except` so we:

1. Log a warning explaining the session reload failed.
2. Recreate `self.api` from scratch (a partially-attempted reload can leave the `APIEdupage` instance in a state that also breaks the subsequent `api.login` call — observed empirically).
3. Fall through to the existing `if not self.api.is_logged_in:` branch, which performs the fresh username/password login.

## Tested

Reproduced the failure on a real HA install with an expired `PHPSESSID` saved from ~4 weeks earlier — `INIT Failed: EDUPAGE error updating get_students() data from API` on every poll, integration stuck in `unavailable` with friendly_name `Unknown Student`.

After the patch (HA restart needed because the Python module is cached):

- Login warning emitted once: `EDUPAGE session reload failed (list index out of range), falling back to fresh login`
- Subsequent fresh login succeeds
- Calendars repopulate with real data (41 timetable events, 5 exams, 3 holidays in my test range)
- No manual re-add of the config entry required

## Notes

- The `# Recreate API instance` line is load-bearing — without it the fallback `api.login` also crashes for the same reason. I assume `reload_data` is mutating shared state on the `APIEdupage` it was handed, but I didn't dig into upstream `edupage-api` to confirm.
- This doesn't address the underlying `list index out of range` bug in `edupage-api`'s `reload_data` — that's an upstream-lib issue. This patch just makes the integration resilient to it.