### PR TITLE
feat: meal/message services, substitution/ringing/term sensors and canteen calendar (follow-up to #96)

### DIFF
--- a/custom_components/homeassistantedupage/__init__.py
+++ b/custom_components/homeassistantedupage/__init__.py
@@ -4,11 +4,15 @@ from datetime import datetime, timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_USERNAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
+import voluptuous as vol
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .homeassistant_edupage import Edupage, EdupageSessionExpired
 from .const import DOMAIN, CONF_PHPSESSID, CONF_SUBDOMAIN, CONF_STUDENT_ID
+from edupage_api.lunches import MealType
+from edupage_api.grades import Term
 
 _LOGGER = logging.getLogger("custom_components.homeassistant_edupage")
 
@@ -119,15 +123,66 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     if meals_to_add:
                         canteen_menu_data[current_date] = meals_to_add
 
+                # Substitution / ringing extras for sensors.
+                try:
+                    timetable_changes = await edupage.get_timetable_changes(today)
+                except Exception as e:  # noqa: BLE001
+                    _LOGGER.warning(
+                        "get_timetable_changes failed for %s: %s", today, e
+                    )
+                    timetable_changes = []
+
+                try:
+                    missing_teachers = await edupage.get_missing_teachers(today)
+                except Exception as e:  # noqa: BLE001
+                    _LOGGER.warning(
+                        "get_missing_teachers failed for %s: %s", today, e
+                    )
+                    missing_teachers = []
+
+                try:
+                    next_ringing = await edupage.get_next_ringing_time(
+                        datetime.now()
+                    )
+                except Exception as e:  # noqa: BLE001
+                    _LOGGER.warning("get_next_ringing_time failed: %s", e)
+                    next_ringing = None
+
+                # Per-term grades for grade-average sensors.
+                school_year = None
+                grades_per_term = {}
+                try:
+                    school_year = await edupage.get_school_year()
+                    term_map = {"first": Term.FIRST, "second": Term.SECOND}
+                    for term_key, term_enum in term_map.items():
+                        try:
+                            grades_per_term[
+                                term_key
+                            ] = await edupage.get_grades_for_term(
+                                school_year, term_enum
+                            )
+                        except Exception as e:  # noqa: BLE001
+                            _LOGGER.warning(
+                                "get_grades_for_term(%s) failed: %s", term_key, e
+                            )
+                            grades_per_term[term_key] = []
+                except Exception as e:  # noqa: BLE001
+                    _LOGGER.warning("get_school_year failed: %s", e)
+                    school_year = None
+
                 return_data = {
                     "student": {"id": student.person_id, "name": student.name},
                     "grades": grades,
                     "subjects": subjects,
                     "timetable": timetable_data,
                     "canteen_menu": canteen_menu_data,
-                    "canteen_calendar_enabled": bool(canteen_menu_data),
                     "cancelled_lessons": timetable_data_canceled,
                     "notifications": notifications,
+                    "timetable_changes": timetable_changes,
+                    "missing_teachers": missing_teachers,
+                    "next_ringing": next_ringing,
+                    "school_year": school_year,
+                    "grades_per_term": grades_per_term,
                     "last_updated": datetime.now().isoformat(),
                 }
                 return return_data
@@ -163,7 +218,191 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, ["calendar", "sensor"])
     _LOGGER.debug("INIT forwarded")
 
+    await _setup_services(hass)
+
     return True
+
+
+# ---------------------------------------------------------------------------
+# Services
+# ---------------------------------------------------------------------------
+
+MEAL_TYPES = {
+    "snack": MealType.SNACK,
+    "lunch": MealType.LUNCH,
+    "afternoon_snack": MealType.AFTERNOON_SNACK,
+}
+
+_services_ready = False
+
+
+def _resolve_coordinator(hass, call: ServiceCall):
+    """Resolve the coordinator targeted by a service call.
+
+    Services are registered ONCE globally (not per config entry) so that
+    multiple student/account entries no longer overwrite each other's handlers.
+    The optional ``entry_id`` in the call data selects a specific entry;
+    otherwise the current (usually single) entry is used. An ``entry_id`` that
+    is supplied but not loaded always raises rather than falling back to
+    another account.
+    """
+    entries = hass.data.get(DOMAIN, {})
+    entry_id = (call.data or {}).get("entry_id")
+    if entry_id and entry_id in entries:
+        return entries[entry_id]
+    if entry_id and entry_id not in entries:
+        raise vol.Invalid(f"EduPage entry_id {entry_id} is not loaded")
+    if not entries:
+        raise vol.Invalid("No EduPage config entry is loaded")
+    if len(entries) > 1 and not entry_id:
+        raise vol.Invalid(
+            "Multiple EduPage entries are loaded; specify 'entry_id' to choose one"
+        )
+    return next(iter(entries.values()))
+
+
+def _find_meal(coordinator, meal_date: str, meal_type: str):
+    """Locate a Meal object from the coordinator's cached canteen data."""
+    try:
+        day = datetime.strptime(meal_date, "%Y-%m-%d").date()
+    except (TypeError, ValueError) as e:
+        raise vol.Invalid("Invalid date, expected YYYY-MM-DD") from e
+
+    meal_type_enum = MEAL_TYPES.get(meal_type.lower())
+    if meal_type_enum is None:
+        raise vol.Invalid(
+            f"Invalid meal_type, expected one of {', '.join(MEAL_TYPES)}"
+        )
+
+    day_meals = coordinator.data.get("canteen_menu", {}).get(day, [])
+    for meal in day_meals:
+        if meal.meal_type == meal_type_enum:
+            return meal
+    raise vol.Invalid(
+        f"No {meal_type} meal found in the canteen data for {meal_date}"
+    )
+
+
+def _find_menu(meal, menu_number):
+    """Locate a Menu (by number) inside a Meal for rating purposes."""
+    for menu in meal.menus or []:
+        if menu.number == str(menu_number):
+            return menu
+    raise vol.Invalid(f"Menu number {menu_number} not found for the given meal")
+
+
+async def _setup_services(hass: HomeAssistant):
+    """Register EduPage services once, globally.
+
+    Registration happens a single time (guarded) so that loading a second
+    config entry cannot replace the handlers of the first. Each service call
+    resolves its target coordinator from the optional ``entry_id``.
+    """
+    global _services_ready
+    if _services_ready:
+        return
+    _services_ready = True
+
+    async def async_choose_meal(call: ServiceCall):
+        coordinator = _resolve_coordinator(hass, call)
+        meal = _find_meal(coordinator, call.data.get("date"), call.data.get("meal_type"))
+        number = call.data.get("number")
+        async with coordinator.fetch_lock:
+            await coordinator.edupage.choose_meal(meal, number)
+        await coordinator.async_request_refresh()
+
+    async def async_sign_off_meal(call: ServiceCall):
+        coordinator = _resolve_coordinator(hass, call)
+        meal = _find_meal(coordinator, call.data.get("date"), call.data.get("meal_type"))
+        async with coordinator.fetch_lock:
+            await coordinator.edupage.sign_off_meal(meal)
+        await coordinator.async_request_refresh()
+
+    async def async_rate_meal(call: ServiceCall):
+        coordinator = _resolve_coordinator(hass, call)
+        meal = _find_meal(coordinator, call.data.get("date"), call.data.get("meal_type"))
+        menu = _find_menu(meal, call.data.get("menu_number"))
+        if menu.rating is None:
+            raise vol.Invalid(
+                "This menu has no rating object; it may not be rateable yet"
+            )
+        quantity = call.data.get("quantity")
+        quality = call.data.get("quality")
+        async with coordinator.fetch_lock:
+            await coordinator.edupage.rate_meal(menu.rating, quantity, quality)
+        await coordinator.async_request_refresh()
+
+    async def async_send_message(call: ServiceCall):
+        coordinator = _resolve_coordinator(hass, call)
+        recipients_raw = call.data.get("recipients")
+        body = call.data.get("body")
+        if isinstance(recipients_raw, str):
+            recipients_raw = [r.strip() for r in recipients_raw.split(",") if r.strip()]
+        if not recipients_raw:
+            raise vol.Invalid("At least one recipient is required")
+        async with coordinator.fetch_lock:
+            await coordinator.edupage.send_message(recipients_raw, body)
+
+    entry_opt = {vol.Optional("entry_id"): cv.string}
+
+    hass.services.async_register(
+        DOMAIN,
+        "choose_meal",
+        async_choose_meal,
+        vol.Schema(
+            {
+                **entry_opt,
+                vol.Required("date"): cv.string,
+                vol.Required("meal_type"): vol.In(list(MEAL_TYPES)),
+                vol.Required("number"): vol.All(
+                    vol.Coerce(int), vol.Range(min=1, max=8)
+                ),
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "sign_off_meal",
+        async_sign_off_meal,
+        vol.Schema(
+            {
+                **entry_opt,
+                vol.Required("date"): cv.string,
+                vol.Required("meal_type"): vol.In(list(MEAL_TYPES)),
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "rate_meal",
+        async_rate_meal,
+        vol.Schema(
+            {
+                **entry_opt,
+                vol.Required("date"): cv.string,
+                vol.Required("meal_type"): vol.In(list(MEAL_TYPES)),
+                vol.Required("menu_number"): cv.string,
+                vol.Required("quantity"): vol.All(
+                    vol.Coerce(int), vol.Range(min=1, max=10)
+                ),
+                vol.Required("quality"): vol.All(
+                    vol.Coerce(int), vol.Range(min=1, max=10)
+                ),
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "send_message",
+        async_send_message,
+        vol.Schema(
+            {
+                **entry_opt,
+                vol.Required("recipients"): cv.ensure_list,
+                vol.Required("body"): cv.string,
+            }
+        ),
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/homeassistantedupage/calendar.py
+++ b/custom_components/homeassistantedupage/calendar.py
@@ -13,7 +13,6 @@ from edupage_api.timetables import Lesson
 from edupage_api.lunches import Meal
 
 _LOGGER = logging.getLogger("custom_components.homeassistant_edupage")
-_LOGGER.debug("CALENDAR Edupage calendar.py is being loaded")
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up Edupage calendar entities."""
@@ -26,28 +25,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     edupage_calendar = EdupageCalendar(coordinator, entry.data)
     calendars.append(edupage_calendar)
 
-    if coordinator.data.get("canteen_calendar_enabled", {}):
-        edupage_canteen_calendar = EdupageCanteenCalendar(coordinator, entry.data)
-        calendars.append(edupage_canteen_calendar)
-        _LOGGER.debug("Canteen calendar added")
-    else:
-        _LOGGER.debug("Canteen calendar skipped, calendar disabled due to exceptions")
+    edupage_canteen_calendar = EdupageCanteenCalendar(coordinator, entry.data)
+    calendars.append(edupage_canteen_calendar)
 
     async_add_entities(calendars)
 
     _LOGGER.debug("CALENDAR async_setup_entry finished.")
 
-async def async_added_to_hass(self) -> None:
-    """When entity is added to hass."""
-    await super().async_added_to_hass()
-    _LOGGER.debug("CALENDAR added to hass")
-
-    if self.coordinator:
-        self.async_on_remove(
-            self.coordinator.async_add_listener(
-                self._handle_coordinator_update, None
-            )
-        )
 
 class EdupageCalendar(CoordinatorEntity, CalendarEntity):
     """Representation of an Edupage calendar entity."""
@@ -57,7 +41,6 @@ class EdupageCalendar(CoordinatorEntity, CalendarEntity):
         self._data = data
         self._events = []
         self._attr_name = "Edupage Calendar"
-        _LOGGER.debug(f"CALENDAR Initialized EdupageCalendar with data: {data}")
 
     @property
     def unique_id(self):
@@ -72,17 +55,8 @@ class EdupageCalendar(CoordinatorEntity, CalendarEntity):
         return f"Edupage - {student_name}"
 
     @property
-    def extra_state_attributes(self):
-        """Return the extra state attributes."""
-        return {
-            "unique_id": self.unique_id,
-            "other_info": "debug info"
-        }
-
-    @property
     def available(self) -> bool:
         """Return True if the calendar is available."""
-        _LOGGER.debug("CALENDAR Checking availability of Edupage Calendar")
         return True
 
     @property
@@ -94,11 +68,8 @@ class EdupageCalendar(CoordinatorEntity, CalendarEntity):
         """Return events in a specific date range."""
         events = []
 
-        _LOGGER.debug(f"CALENDAR Fetching events between {start_date} and {end_date}")
         timetable = self.coordinator.data.get("timetable", {})
         timetable_canceled = self.coordinator.data.get("cancelled_lessons", {})
-        _LOGGER.debug(f"CALENDAR Coordinator data: {self.coordinator.data}")
-        _LOGGER.debug(f"CALENDAR Fetched timetable data: {timetable}")
 
         if not timetable:
             _LOGGER.warning("CALENDAR Timetable data is missing.")
@@ -110,7 +81,6 @@ class EdupageCalendar(CoordinatorEntity, CalendarEntity):
             events.extend(self.get_events(timetable_canceled, current_date))
             current_date += timedelta(days=1)
 
-        _LOGGER.debug(f"CALENDAR Fetched {len(events)} events from {start_date} to {end_date}")
         return events
 
     def get_events(self, timetable, current_date):
@@ -118,19 +88,15 @@ class EdupageCalendar(CoordinatorEntity, CalendarEntity):
         day_timetable = timetable.get(current_date)
         if day_timetable:
             for lesson in day_timetable:
-
-                _LOGGER.debug(f"CALENDAR Lesson attributes: {vars(lesson)}")
-
                 events.append(
                     self.map_lesson_to_calender_event(lesson, current_date)
                 )
         return events
 
-
     def map_lesson_to_calender_event(self, lesson: Lesson, day: date) -> CalendarEvent:
         teacher_names = [teacher.name for teacher in lesson.teachers] if lesson.teachers else []
         teachers = ", ".join(teacher_names) if teacher_names else "Unknown Teacher"
-        description=f"Teacher(s): {teachers}"
+        description = f"Teacher(s): {teachers}"
         room = None
         if lesson.classrooms:
             room = lesson.classrooms[0].name
@@ -144,45 +110,63 @@ class EdupageCalendar(CoordinatorEntity, CalendarEntity):
         cal_event = CalendarEvent(
             start=start_time,
             end=end_time,
-            summary= lesson_subject_prefix + lesson_subject,
+            summary=lesson_subject_prefix + lesson_subject,
             description=description,
-            location=room
+            location=room,
         )
         return cal_event
 
-    # Funktion zum Filtern und Finden der nächsten passenden Lesson
     def find_lesson_now_or_next_across_days(self) -> Optional[CalendarEvent]:
         lessons_by_day = self.coordinator.data.get("timetable", {})
-        current_time = datetime.now().time()  # Aktuelle Uhrzeit
-        current_day = datetime.date(datetime.now())  # Aktueller Wochentag
+        current_time = datetime.now().time()
+        current_day = datetime.now().date()
 
-        # Schritt 1: Suche im aktuellen Tag
+        # Step 1: look for a lesson currently in progress.
         lessons_today = lessons_by_day.get(current_day, [])
-        current_lesson = next((lesson for lesson in lessons_today
-                               if lesson.start_time <= current_time <= lesson.end_time), None)
-
+        current_lesson = next(
+            (
+                lesson
+                for lesson in lessons_today
+                if lesson.start_time <= current_time <= lesson.end_time
+            ),
+            None,
+        )
         if current_lesson:
-            return self.map_lesson_to_calender_event(current_lesson, current_day)  # Falls eine aktuelle Lesson gefunden wird
+            return self.map_lesson_to_calender_event(current_lesson, current_day)
 
-        # Schritt 2: Finde die nächste Lesson heute oder an zukünftigen Tagen
+        # Step 2: find the next lesson today or on a future day.
+        # Compare full datetimes (day + start_time) so a lesson today at 10:00
+        # is always selected ahead of a lesson tomorrow at 08:00.
+        next_lesson_day = None
         next_lesson = None
-        for day, lessons in sorted(lessons_by_day.items(), key=lambda x: x[0]):  # Nach Tagen sortieren
-            # Überspringe vergangene Tage
+        next_lesson_start = None
+        for day, lessons in sorted(lessons_by_day.items(), key=lambda x: x[0]):
             if day < current_day:
                 continue
+            future_lessons = [
+                lesson
+                for lesson in lessons
+                if day > current_day or lesson.start_time > current_time
+            ]
+            if not future_lessons:
+                continue
+            candidate_start = min(
+                (datetime.combine(day, lesson.start_time) for lesson in future_lessons)
+            )
+            if next_lesson_start is None or candidate_start < next_lesson_start:
+                next_lesson_start = candidate_start
+                next_lesson = next(
+                    lesson
+                    for lesson in future_lessons
+                    if datetime.combine(day, lesson.start_time) == candidate_start
+                )
+                next_lesson_day = day
 
-            # Prüfe Lektionen heute (nach current_time) oder in zukünftigen Tagen
-            future_lessons = [lesson for lesson in lessons if day > current_day or lesson.start_time > current_time]
-            if future_lessons:
-                # Die früheste Lesson finden
-                next_lesson_today_or_future = min(future_lessons, key=lambda x: x.start_time)
-                if next_lesson is None or next_lesson_today_or_future.start_time < next_lesson.start_time:
-                    next_lesson = next_lesson_today_or_future
-
-                if next_lesson:
-                    return self.map_lesson_to_calender_event(next_lesson, day)
+        if next_lesson and next_lesson_day:
+            return self.map_lesson_to_calender_event(next_lesson, next_lesson_day)
 
         return None
+
 
 class EdupageCanteenCalendar(CoordinatorEntity, CalendarEntity):
     """Representation of an Edupage canteen calendar entity."""
@@ -192,7 +176,6 @@ class EdupageCanteenCalendar(CoordinatorEntity, CalendarEntity):
         self._data = data
         self._events = []
         self._attr_name = "Edupage Canteen Calendar"
-        _LOGGER.debug(f"CALENDAR Initialized EdupageCanteenCalendar with data: {data}")
 
     @property
     def unique_id(self):
@@ -207,32 +190,20 @@ class EdupageCanteenCalendar(CoordinatorEntity, CalendarEntity):
         return f"Edupage Canteen - {student_name}"
 
     @property
-    def extra_state_attributes(self):
-        """Return the extra state attributes."""
-        return {
-            "unique_id": self.unique_id,
-            "other_info": "debug info"
-        }
-
-    @property
     def available(self) -> bool:
         """Return True if the calendar is available."""
-        _LOGGER.debug("CALENDAR Checking availability of Edupage Canteen Calendar")
         return True
 
     @property
     def event(self):
-        """Return the next upcoming event or None if no event exists."""
+        """Return the next upcoming meal event or None if none exists."""
         return self.find_meal_now_or_next_across_days()
 
     async def async_get_events(self, hass, start_date: datetime, end_date: datetime):
-        """Return events in a specific date range."""
+        """Return canteen meal events in a specific date range."""
         events = []
 
-        _LOGGER.debug(f"CALENDAR Fetching canteen calendar between {start_date} and {end_date}")
         canteen_menu = self.coordinator.data.get("canteen_menu", {})
-        _LOGGER.debug(f"CALENDAR Coordinator data: {self.coordinator.data}")
-        _LOGGER.debug(f"CALENDAR Fetched canteen_menu data: {canteen_menu}")
 
         if not canteen_menu:
             _LOGGER.warning("CALENDAR Canteen menu data is missing.")
@@ -243,7 +214,6 @@ class EdupageCanteenCalendar(CoordinatorEntity, CalendarEntity):
             events.extend(self.get_events(canteen_menu, current_date))
             current_date += timedelta(days=1)
 
-        _LOGGER.debug(f"CALENDAR Fetched {len(events)} events from {start_date} to {end_date}")
         return events
 
     def get_events(self, canteen_menu, current_date):
@@ -251,28 +221,78 @@ class EdupageCanteenCalendar(CoordinatorEntity, CalendarEntity):
         daily_menu = canteen_menu.get(current_date)
         if daily_menu:
             for meal in daily_menu:
-                _LOGGER.debug(f"CALENDAR Meal attributes: {vars(meal)}")
-                events.append(
-                    self.map_meal_to_calender_event(meal, current_date)
-                )
+                events.append(self.map_meal_to_calender_event(meal, current_date))
         return events
 
-
-    def map_meal_to_calender_event(self, meal: Meal, day: date) -> CalendarEvent:
+    def map_meal_to_calender_event(self, meal: Meal, day: date) -> Optional[CalendarEvent]:
         local_tz = ZoneInfo(self.hass.config.time_zone)
-        start_time = datetime.combine(day, meal.served_from.time()).astimezone(local_tz)
-        end_time = datetime.combine(day, meal.served_to.time()).astimezone(local_tz)
-        summary = meal.meal_type.name
+        if meal.served_from is None or meal.served_to is None:
+            # No serving window exposed by EduPage; show an all-event-day slot.
+            start_time = datetime.combine(day, datetime.min.time()).astimezone(local_tz)
+            end_time = start_time + timedelta(days=1)
+        else:
+            start_time = datetime.combine(day, meal.served_from.time()).astimezone(local_tz)
+            end_time = datetime.combine(day, meal.served_to.time()).astimezone(local_tz)
+            if end_time <= start_time:
+                end_time = end_time + timedelta(days=1)
+
+        summary = meal.meal_type.name.replace("_", " ").capitalize()
         description = meal.title
 
-        cal_event = CalendarEvent(
+        return CalendarEvent(
             start=start_time,
             end=end_time,
             summary=summary,
-            description=description
+            description=description,
         )
-        return cal_event
 
     def find_meal_now_or_next_across_days(self) -> Optional[CalendarEvent]:
-        # TODO implement
+        canteen_menu = self.coordinator.data.get("canteen_menu", {})
+        now = datetime.now()
+        today = now.date()
+
+        # Each entry is (day, meal, start_datetime_or_None, end_datetime_or_None).
+        # All values are datetimes (or None) so they can be compared against
+        # ``now`` without mixing ``datetime.time`` and ``datetime.datetime``.
+        meals_by_time = []
+        for day, meals in canteen_menu.items():
+            for meal in meals:
+                if day < today:
+                    continue
+                if meal.served_from is None:
+                    # No serving window exposed by EduPage: the meal occupies
+                    # the whole day (midnight -> next midnight).
+                    start_dt = datetime.combine(day, datetime.min.time())
+                    end_dt = start_dt + timedelta(days=1)
+                    meals_by_time.append((day, meal, start_dt, end_dt))
+                    continue
+                start_dt = datetime.combine(day, meal.served_from.time())
+                end_dt = (
+                    datetime.combine(day, meal.served_to.time())
+                    if meal.served_to
+                    else None
+                )
+                meals_by_time.append((day, meal, start_dt, end_dt))
+
+        # A meal currently being served is the "event" right now.
+        for day, meal, start_dt, end_dt in meals_by_time:
+            if day == today and start_dt is not None and end_dt is not None:
+                if start_dt <= now <= end_dt:
+                    return self.map_meal_to_calender_event(meal, day)
+
+        # Otherwise the next future meal.
+        next_meal = None
+        next_day = None
+        next_start = None
+        for day, meal, start_dt, end_dt in meals_by_time:
+            candidate = start_dt or datetime.combine(day, datetime.min.time())
+            if candidate > now:
+                if next_start is None or candidate < next_start:
+                    next_start = candidate
+                    next_meal = meal
+                    next_day = day
+
+        if next_meal and next_day:
+            return self.map_meal_to_calender_event(next_meal, next_day)
+
         return None

--- a/custom_components/homeassistantedupage/homeassistant_edupage.py
+++ b/custom_components/homeassistantedupage/homeassistant_edupage.py
@@ -181,3 +181,139 @@ class Edupage:
             raise UpdateFailed(
                 f"EDUPAGE error updating get_meals() data for {day}: {e}"
             )
+
+    async def get_timetable_changes(self, day):
+        try:
+            return await self.hass.async_add_executor_job(
+                self.api.get_timetable_changes, day
+            )
+        except Exception as e:  # noqa: BLE001
+            raise UpdateFailed(
+                f"EDUPAGE error updating get_timetable_changes() data for {day}: {e}"
+            )
+
+    async def get_missing_teachers(self, day):
+        try:
+            return await self.hass.async_add_executor_job(
+                self.api.get_missing_teachers, day
+            )
+        except Exception as e:  # noqa: BLE001
+            raise UpdateFailed(
+                f"EDUPAGE error updating get_missing_teachers() data for {day}: {e}"
+            )
+
+    async def get_next_ringing_time(self, day_time):
+        try:
+            return await self.hass.async_add_executor_job(
+                self.api.get_next_ringing_time, day_time
+            )
+        except Exception as e:  # noqa: BLE001
+            raise UpdateFailed(
+                f"EDUPAGE error updating get_next_ringing_time() data from API: {e}"
+            )
+
+    async def get_school_year(self) -> int:
+        """Returns the current school year."""
+        try:
+            return await self.hass.async_add_executor_job(self.api.get_school_year)
+        except Exception as e:  # noqa: BLE001
+            raise UpdateFailed(
+                f"EDUPAGE error updating get_school_year() data from API: {e}"
+            )
+
+    async def get_grades_for_term(self, year: int, term):
+        """Returns grades for a specific school term."""
+        try:
+            return await self.hass.async_add_executor_job(
+                self.api.get_grades_for_term, year, term
+            )
+        except Exception as e:  # noqa: BLE001
+            raise UpdateFailed(
+                f"EDUPAGE error updating get_grades_for_term() data from API: {e}"
+            )
+
+    # ------------------------------------------------------------------
+    # Action methods used by services
+    # ------------------------------------------------------------------
+
+    async def choose_meal(self, meal, number: int):
+        try:
+            await self.hass.async_add_executor_job(meal.choose, self.api, number)
+        except Exception as e:  # noqa: BLE001
+            raise UpdateFailed(f"EDUPAGE error choosing meal: {e}")
+
+    async def sign_off_meal(self, meal):
+        try:
+            await self.hass.async_add_executor_job(meal.sign_off, self.api)
+        except Exception as e:  # noqa: BLE001
+            raise UpdateFailed(f"EDUPAGE error signing off meal: {e}")
+
+    async def rate_meal(self, rating, quantity: int, quality: int):
+        try:
+            await self.hass.async_add_executor_job(
+                rating.rate, self.api, quantity, quality
+            )
+        except Exception as e:  # noqa: BLE001
+            raise UpdateFailed(f"EDUPAGE error rating meal: {e}")
+
+    async def resolve_recipients(self, recipients):
+        """Resolve recipient strings to EduPage account objects.
+
+        ``edupage-api``'s ``send_message`` expects account objects (or their
+        ``get_id()`` strings like ``s123``/``u456``). A free-text name would be
+        sent verbatim as ``selectedUser`` and fail against EduPage. We therefore
+        match each recipient against the known students and teachers (by numeric
+        ``person_id`` or by case-insensitive name) and raise if one cannot be
+        resolved.
+        """
+        names = []
+        ids = []
+        for raw in recipients:
+            raw = str(raw).strip()
+            if not raw:
+                continue
+            if raw.isdigit():
+                ids.append(raw)
+            else:
+                names.append(raw)
+        if not names and not ids:
+            raise UpdateFailed("EduPage send_message: no recipients given")
+
+        resolved = []
+        unmatched = list(names)
+        for account_list in (await self.get_students(), await self.get_teachers()):
+            for account in account_list or []:
+                needle = str(account.person_id)
+                if needle in ids:
+                    resolved.append(account)
+                    ids.remove(needle)
+                elif account.name and account.name.lower() in [n.lower() for n in unmatched]:
+                    resolved.append(account)
+                    matched_name = next(n for n in unmatched if n.lower() == account.name.lower())
+                    unmatched.remove(matched_name)
+
+        if ids:
+            raise UpdateFailed(
+                f"EduPage send_message: could not resolve recipient id(s): {', '.join(ids)}"
+            )
+        if unmatched:
+            raise UpdateFailed(
+                f"EduPage send_message: could not resolve recipient(s): {', '.join(unmatched)}"
+            )
+        return resolved
+
+    async def send_message(self, recipients, body: str):
+        try:
+            accounts = await self.resolve_recipients(recipients)
+            # edupage-api 0.12.5 sends the first ``selectedUser`` using the exact
+            # ``EduAccount`` type check; student/teacher subclasses are not
+            # accepted and would be string-joined, so we pass the resolved
+            # recipient IDs (e.g. ``s123``/``u456``) instead of the objects.
+            recipient_ids = [account.get_id() for account in accounts]
+            return await self.hass.async_add_executor_job(
+                self.api.send_message, recipient_ids, body
+            )
+        except UpdateFailed:
+            raise
+        except Exception as e:  # noqa: BLE001
+            raise UpdateFailed(f"EDUPAGE error sending message: {e}")

--- a/custom_components/homeassistantedupage/manifest.json
+++ b/custom_components/homeassistantedupage/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/rine77/homeassistantedupage/issues",
     "requirements": ["edupage-api==0.12.5", "unidecode"],
-    "version": "0.4.0"
+    "version": "0.5.0"
 }

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -1,5 +1,6 @@
 import logging
 from collections import defaultdict
+from datetime import datetime
 
 from unidecode import unidecode
 from homeassistant.components.sensor import SensorEntity
@@ -54,6 +55,35 @@ async def async_setup_entry(
     sensors.append(
         EduPageNotificationSensor(
             coordinator, student.get("id"), student.get("name"), notifications
+        )
+    )
+    sensors.append(
+        EduPageSubstitutionSensor(
+            coordinator, student.get("id"), student.get("name"), "timetable_changes"
+        )
+    )
+    sensors.append(
+        EduPageSubstitutionSensor(
+            coordinator, student.get("id"), student.get("name"), "missing_teachers"
+        )
+    )
+    sensors.append(
+        EduPageRingingSensor(coordinator, student.get("id"), student.get("name"))
+    )
+    sensors.append(
+        EduPageTermAverageSensor(
+            coordinator,
+            student.get("id"),
+            student.get("name"),
+            term_key="first",
+        )
+    )
+    sensors.append(
+        EduPageTermAverageSensor(
+            coordinator,
+            student.get("id"),
+            student.get("name"),
+            term_key="second",
         )
     )
 
@@ -189,7 +219,9 @@ class EduPageNotificationSensor(CoordinatorEntity, SensorEntity):
             events.append(item)
         attributes["events"] = events
 
-        for i, event in enumerate(notifications):
+        # Flat per-event attributes are kept for backwards compatibility but
+        # must also be bounded to avoid unbounded state-attribute growth.
+        for i, event in enumerate(notifications[:_MAX_EVENTS]):
             attributes[f"event_{i+1}_id"] = event.event_id
             attributes[f"event_{i+1}_type"] = (
                 getattr(event.event_type, "value", None) or str(event.event_type)
@@ -218,3 +250,177 @@ class EduPageNotificationSensor(CoordinatorEntity, SensorEntity):
             if subject.subject_id == subject_id:
                 return subject.name
         return None
+
+
+def _subject_slug(name):
+    return unidecode(name).replace(" ", "_").lower()
+
+
+def _grade_numeric(grade_n):
+    """Best-effort numeric conversion of a grade value for averaging."""
+    if grade_n is None:
+        return None
+    if isinstance(grade_n, (int, float)):
+        return float(grade_n)
+    try:
+        return float(str(grade_n).replace(",", "."))
+    except (TypeError, ValueError):
+        return None
+
+
+def _average(grades):
+    """Weighted-agnostic arithmetic mean of numeric grade values."""
+    values = [v for v in (_grade_numeric(g.grade_n) for g in grades) if v is not None]
+    return round(sum(values) / len(values), 2) if values else None
+
+
+class EduPageSubstitutionSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for timetable changes or missing teachers for the current day."""
+
+    def __init__(self, coordinator, student_id, student_name, data_key):
+        """data_key is 'timetable_changes' or 'missing_teachers'."""
+        super().__init__(coordinator)
+
+        self._student_id = student_id
+        self._student_name = _subject_slug(student_name)
+        self._data_key = data_key
+        label = (
+            "Timetable Changes"
+            if data_key == "timetable_changes"
+            else "Missing Teachers"
+        )
+
+        self._attr_name = f"Edupage - {label} {student_name}"
+
+        self._unique_id = f"edupage_{data_key}_{self._student_id}_{self._student_name}"
+
+    @property
+    def unique_id(self):
+        """Return a unique identifier for this sensor."""
+        return self._unique_id
+
+    @property
+    def state(self):
+        return len(self.coordinator.data.get(self._data_key, []))
+
+    @property
+    def extra_state_attributes(self):
+        entries = self.coordinator.data.get(self._data_key, [])
+        attributes = {
+            "student": self.coordinator.data.get("student", {}),
+            "unique_id": self._unique_id,
+            "date": datetime.now().strftime("%Y-%m-%d"),
+            "count": len(entries),
+            "last_updated": self.coordinator.data.get("last_updated"),
+        }
+        if self._data_key == "timetable_changes":
+            for i, change in enumerate(entries):
+                attributes[f"change_{i+1}_class"] = change.change_class
+                attributes[f"change_{i+1}_lesson"] = change.lesson_n
+                attributes[f"change_{i+1}_title"] = change.title
+                attributes[f"change_{i+1}_action"] = change.action
+        else:
+            for i, teacher in enumerate(entries):
+                attributes[f"teacher_{i+1}_name"] = teacher.name
+                attributes[f"teacher_{i+1}_id"] = teacher.person_id
+        return attributes
+
+
+class EduPageRingingSensor(CoordinatorEntity, SensorEntity):
+    """Sensor exposing the next school-bell ringing time."""
+
+    def __init__(self, coordinator, student_id, student_name):
+        super().__init__(coordinator)
+        self._student_id = student_id
+        self._student_name = _subject_slug(student_name)
+        self._attr_name = f"Edupage - Next Ringing {student_name}"
+        self._unique_id = (
+            f"edupage_next_ringing_{self._student_id}_{self._student_name}"
+        )
+
+    @property
+    def unique_id(self):
+        return self._unique_id
+
+    @property
+    def state(self):
+        ringing = self.coordinator.data.get("next_ringing")
+        if ringing is None:
+            return "unknown"
+        return ringing.time.strftime("%H:%M")
+
+    @property
+    def extra_state_attributes(self):
+        ringing = self.coordinator.data.get("next_ringing")
+        attrs = {
+            "student": self.coordinator.data.get("student", {}),
+            "unique_id": self._unique_id,
+        }
+        if ringing is not None:
+            attrs["ringing_type"] = ringing.type.name
+            attrs["time"] = ringing.time.strftime("%H:%M")
+            attrs["date"] = datetime.now().strftime("%Y-%m-%d")
+        return attrs
+
+
+class EduPageTermAverageSensor(CoordinatorEntity, SensorEntity):
+    """Sensor showing grade count and average for a specific school term.
+
+    Reads the per-term grades live from the coordinator each poll, so the
+    average follows later coordinator updates instead of freezing the initial
+    snapshot.
+    """
+
+    def __init__(self, coordinator, student_id, student_name, term_key):
+        super().__init__(coordinator)
+        self._student_id = student_id
+        self._student_name = _subject_slug(student_name)
+        self._term_key = term_key
+        term_label = "1st" if term_key == "first" else "2nd"
+
+        self._attr_name = f"Edupage - {term_label} Term Average {student_name}"
+
+        self._unique_id = (
+            f"edupage_term_{term_key}_{self._student_id}_{self._student_name}"
+        )
+
+    @property
+    def unique_id(self):
+        return self._unique_id
+
+    @property
+    def _current_grades(self):
+        return self.coordinator.data.get("grades_per_term", {}).get(
+            self._term_key, []
+        )
+
+    @property
+    def _school_year(self):
+        return self.coordinator.data.get("school_year")
+
+    @property
+    def state(self):
+        avg = _average(self._current_grades)
+        return avg if avg is not None else "unknown"
+
+    @property
+    def extra_state_attributes(self):
+        grades = self._current_grades
+        by_subject = defaultdict(list)
+        for grade in grades:
+            by_subject[grade.subject_name or grade.subject_id].append(grade)
+
+        subject_averages = {
+            str(subject): _average(subject_grades)
+            for subject, subject_grades in by_subject.items()
+        }
+
+        return {
+            "student": self.coordinator.data.get("student", {}),
+            "unique_id": self._unique_id,
+            "school_year": self._school_year,
+            "term": self._term_key,
+            "grade_count": len(grades),
+            "grade_average": _average(grades),
+            "subject_averages": subject_averages,
+        }

--- a/custom_components/homeassistantedupage/services.yaml
+++ b/custom_components/homeassistantedupage/services.yaml
@@ -1,0 +1,112 @@
+choose_meal:
+  description: Select (choose) a canteen meal for the given day and meal type.
+  fields:
+    date:
+      description: Date of the meal in YYYY-MM-DD format.
+      example: "2026-09-03"
+      required: true
+    meal_type:
+      description: Type of meal to choose.
+      example: lunch
+      required: true
+      selector:
+        select:
+          options:
+            - snack
+            - lunch
+            - afternoon_snack
+    number:
+      description: Menu number to select (1-8).
+      example: 2
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box
+    entry_id:
+      description: Config entry ID to target when multiple EduPage entries are loaded.
+      example: 01J4XYZABC
+      required: false
+
+sign_off_meal:
+  description: Sign off (cancel) the selected canteen meal for the given day and meal type.
+  fields:
+    date:
+      description: Date of the meal in YYYY-MM-DD format.
+      example: "2026-09-03"
+      required: true
+    meal_type:
+      description: Type of meal to sign off.
+      example: lunch
+      required: true
+      selector:
+        select:
+          options:
+            - snack
+            - lunch
+            - afternoon_snack
+    entry_id:
+      description: Config entry ID to target when multiple EduPage entries are loaded.
+      example: 01J4XYZABC
+      required: false
+
+rate_meal:
+  description: Rate a canteen meal menu by quantity and quality.
+  fields:
+    date:
+      description: Date of the meal in YYYY-MM-DD format.
+      example: "2026-09-03"
+      required: true
+    meal_type:
+      description: Type of meal to rate.
+      example: lunch
+      required: true
+      selector:
+        select:
+          options:
+            - snack
+            - lunch
+            - afternoon_snack
+    menu_number:
+      description: Menu number to rate.
+      example: "2"
+      required: true
+    quantity:
+      description: Quantity rating (1-10).
+      example: 8
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 10
+          mode: box
+    quality:
+      description: Quality rating (1-10).
+      example: 9
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 10
+          mode: box
+    entry_id:
+      description: Config entry ID to target when multiple EduPage entries are loaded.
+      example: 01J4XYZABC
+      required: false
+
+send_message:
+  description: Send a message to EduPage recipients (students or teachers).
+  fields:
+    recipients:
+      description: One or more recipients, by numeric person ID or case-insensitive name.
+      example: ["Test User", "12345"]
+      required: true
+    body:
+      description: Message body text.
+      example: "Please bring your homework tomorrow."
+      required: true
+    entry_id:
+      description: Config entry ID to target when multiple EduPage entries are loaded.
+      example: 01J4XYZABC
+      required: false

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -1,0 +1,221 @@
+"""Tests for the "extras" split-out: meal services, message sending, the
+canteen calendar (serving-time handling and always-created entity) and the
+term-average helpers.
+
+These mirror the lightweight wrapper pattern from ``test_edupage_wrapper.py``:
+``_FakeHass`` runs sync callables inline so the async EduPage wrapper can be
+exercised without a live Home Assistant instance. Coordinator-based pieces use
+the pytest-homeassistant-custom-component ``hass`` fixture.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.homeassistantedupage.homeassistant_edupage import (
+    Edupage,
+    UpdateFailed,
+)
+from custom_components.homeassistantedupage.sensor import _average, _grade_numeric
+
+
+class _FakeHass:
+    """Minimal hass whose async_add_executor_job runs the sync callable inline."""
+
+    async def async_add_executor_job(self, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+
+def _wrapper(api):
+    wrapper = Edupage(_FakeHass(), sessionid="sess")
+    wrapper.api = api
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Term-average helpers
+# ---------------------------------------------------------------------------
+
+
+class _Grade:
+    def __init__(self, grade_n):
+        self.grade_n = grade_n
+
+
+def test_grade_numeric_handles_numeric_and_invalid_values():
+    assert _grade_numeric(1) == 1.0
+    assert _grade_numeric("2") == 2.0
+    assert _grade_numeric("2,5") == 2.5
+    assert _grade_numeric(None) is None
+    assert _grade_numeric("abc") is None
+
+
+def test_average_ignores_non_numeric_grades():
+    grades = [_Grade(1), _Grade("2"), _Grade("abc"), _Grade(None), _Grade(3)]
+    # 1 + 2 + 3 = 6 / 3 = 2.0 (the "abc"/None entries are skipped)
+    assert _average(grades) == 2.0
+
+
+def test_average_empty_returns_none():
+    assert _average([]) is None
+    assert _average([_Grade("abc")]) is None
+
+
+# ---------------------------------------------------------------------------
+# Meal services (choose / sign off / rate)
+# ---------------------------------------------------------------------------
+
+
+async def test_choose_meal_calls_meal_choose():
+    api = MagicMock()
+    meal = MagicMock()
+    await _wrapper(api).choose_meal(meal, 3)
+    meal.choose.assert_called_once_with(api, 3)
+
+
+async def test_sign_off_meal_calls_meal_sign_off():
+    api = MagicMock()
+    meal = MagicMock()
+    await _wrapper(api).sign_off_meal(meal)
+    meal.sign_off.assert_called_once_with(api)
+
+
+async def test_rate_meal_calls_rating_rate():
+    api = MagicMock()
+    rating = MagicMock()
+    await _wrapper(api).rate_meal(rating, 8, 9)
+    rating.rate.assert_called_once_with(api, 8, 9)
+
+
+async def test_choose_meal_propagates_failure_as_update_failed():
+    api = MagicMock()
+    meal = MagicMock()
+    meal.choose.side_effect = RuntimeError("boom")
+    with pytest.raises(UpdateFailed):
+        await _wrapper(api).choose_meal(meal, 3)
+
+
+# ---------------------------------------------------------------------------
+# Message recipient resolution
+# ---------------------------------------------------------------------------
+
+
+class _Account:
+    def __init__(self, person_id, name, get_id=None):
+        self.person_id = person_id
+        self.name = name
+        # Mimic edupage-api account objects (``get_id()`` returns e.g. s123/u456).
+        self._get_id = get_id or f"s{person_id}"
+
+    def get_id(self):
+        return self._get_id
+
+
+class _ApiWithPeople:
+    def get_students(self):
+        return [_Account(1, "Alice"), _Account(2, "Bob")]
+
+    def get_teachers(self):
+        return [_Account(100, "Mrs Smith")]
+
+
+async def test_resolve_recipients_by_id_and_name():
+    wrapper = _wrapper(_ApiWithPeople())
+    resolved = await wrapper.resolve_recipients(["1", "2", "mrs smith"])
+    assert {a.person_id for a in resolved} == {1, 2, 100}
+
+
+async def test_resolve_recipients_raises_on_unknown():
+    wrapper = _wrapper(_ApiWithPeople())
+    with pytest.raises(UpdateFailed):
+        await wrapper.resolve_recipients(["nobody"])
+
+
+async def test_send_message_passes_recipient_ids_not_objects():
+    """send_message must hand the API resolved recipient ID strings, not the
+    account objects (edupage-api 0.12.5 rejects EduStudent/EduTeacher subclasses
+    via an exact EduAccount type check)."""
+    api = MagicMock()
+    student = _Account(1, "Alice", get_id="Student123")
+    teacher = _Account(2, "Mrs Smith", get_id="Teacher456")
+    api.get_students.return_value = [student]
+    api.get_teachers.return_value = [teacher]
+    wrapper = _wrapper(api)
+    await wrapper.send_message(["1", "Mrs Smith"], "hello")
+    args, _ = api.send_message.call_args
+    assert args[0] == ["Student123", "Teacher456"]
+    assert args[1] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Canteen calendar: serving-time handling and always-created entity
+# ---------------------------------------------------------------------------
+
+
+class _MealType:
+    def __init__(self, name):
+        self.name = name
+
+
+class _Meal:
+    def __init__(self, meal_type, served_from=None, served_to=None, title="Menu"):
+        self.meal_type = _MealType(meal_type)
+        self.served_from = served_from
+        self.served_to = served_to
+        self.title = title
+
+
+@pytest.fixture
+def canteen_calendar(hass: HomeAssistant):
+    from custom_components.homeassistantedupage.calendar import EdupageCanteenCalendar
+
+    coord = MagicMock()
+    coord.data = {"canteen_menu": {}}
+    cal = EdupageCanteenCalendar(coord, {})
+    cal.hass = hass
+    return cal
+
+
+def test_map_meal_with_serving_times(canteen_calendar):
+    meal = _Meal(
+        "LUNCH",
+        served_from=datetime(2026, 9, 3, 11, 0),
+        served_to=datetime(2026, 9, 3, 13, 0),
+    )
+    event = canteen_calendar.map_meal_to_calender_event(meal, datetime(2026, 9, 3).date())
+    # Duration between the serving window end and start is timezone-independent.
+    assert event.end - event.start == timedelta(hours=2)
+
+
+def test_map_meal_without_serving_times_spans_day(canteen_calendar):
+    meal = _Meal("LUNCH", served_from=None, served_to=None)
+    day = datetime(2026, 9, 3).date()
+    event = canteen_calendar.map_meal_to_calender_event(meal, day)
+    # No serving window: the meal occupies the whole day (midnight -> next midnight).
+    assert event.end - event.start == timedelta(days=1)
+
+
+def test_empty_canteen_menu_returns_no_event(canteen_calendar):
+    canteen_calendar.coordinator.data = {"canteen_menu": {}}
+    assert canteen_calendar.event is None
+
+
+async def test_always_creates_canteen_calendar(hass: HomeAssistant):
+    """The canteen calendar entity must always be created, even with no menu."""
+    from custom_components.homeassistantedupage import calendar as calendar_module
+
+    coord = MagicMock()
+    coord.data = {"canteen_menu": {}}
+    entry = MagicMock()
+    hass.data["homeassistantedupage"] = {entry.entry_id: coord}
+
+    added = []
+    await calendar_module.async_setup_entry(
+        hass, entry, lambda entities: added.extend(entities)
+    )
+
+    names = {type(e).__name__ for e in added}
+    assert "EdupageCalendar" in names
+    assert "EdupageCanteenCalendar" in names

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -125,3 +125,16 @@ async def test_events_list_keeps_first_max_events(hass, coordinator):
     # first _MAX_EVENTS entries are kept when the list is capped.
     assert events[0]["id"] == 0
     assert events[-1]["id"] == _MAX_EVENTS - 1
+
+
+async def test_flat_event_attributes_are_bounded(hass, coordinator):
+    """The flat event_N_* attributes must also be capped at _MAX_EVENTS."""
+    sensor = _make_sensor(coordinator)
+    coordinator.data["notifications"] = [
+        _FakeEvent(i, "homework", f"n{i}", datetime(2026, 9, 1))
+        for i in range(_MAX_EVENTS + 20)
+    ]
+    attrs = sensor.extra_state_attributes
+    # Only the first _MAX_EVENTS events are emitted as flat attributes.
+    assert attrs[f"event_{_MAX_EVENTS}_id"] == _MAX_EVENTS - 1
+    assert f"event_{_MAX_EVENTS + 1}_id" not in attrs

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,57 @@
+"""Tests for the global EduPage service registration and its coordinator
+resolution.
+
+Services are registered once, globally, and target a coordinator chosen via the
+optional ``entry_id``. ``_resolve_coordinator`` must pick a specific entry when
+``entry_id`` is given, reject ambiguity when several entries exist and none is
+named, and return the single entry when only one is loaded.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import voluptuous as vol
+from homeassistant.core import HomeAssistant
+
+import custom_components.homeassistantedupage as init_module
+from custom_components.homeassistantedupage.const import DOMAIN
+
+
+def _call(data):
+    call = MagicMock()
+    call.data = data
+    return call
+
+
+def test_resolve_single_entry_without_id(hass: HomeAssistant):
+    coord = object()
+    hass.data[DOMAIN] = {"a": coord}
+    assert init_module._resolve_coordinator(hass, _call({})) is coord
+
+
+def test_resolve_by_entry_id(hass: HomeAssistant):
+    coord_a = object()
+    coord_b = object()
+    hass.data[DOMAIN] = {"a": coord_a, "b": coord_b}
+    assert init_module._resolve_coordinator(hass, _call({"entry_id": "b"})) is coord_b
+
+
+def test_resolve_unknown_entry_id_raises(hass: HomeAssistant):
+    """An explicitly supplied entry_id that is not loaded must raise, not fall
+    back to the only loaded entry (acting on the wrong account is risky)."""
+    coord_a = object()
+    hass.data[DOMAIN] = {"a": coord_a}
+    with pytest.raises(vol.Invalid):
+        init_module._resolve_coordinator(hass, _call({"entry_id": "does-not-exist"}))
+
+
+def test_resolve_missing_entry_id_raises_when_ambiguous(hass: HomeAssistant):
+    hass.data[DOMAIN] = {"a": object(), "b": object()}
+    with pytest.raises(vol.Invalid):
+        init_module._resolve_coordinator(hass, _call({}))
+
+
+def test_resolve_with_no_entries_raises(hass: HomeAssistant):
+    hass.data[DOMAIN] = {}
+    with pytest.raises(vol.Invalid):
+        init_module._resolve_coordinator(hass, _call({}))


### PR DESCRIPTION
# Follow-up: meal/message services, substitution/ringing/term sensors and canteen calendar

This PR carries the features that were split out of PR #96 so nothing is lost,
and it fixes the issues flagged in that (expanded) review. It has been rebased
onto the merged #96 (`main` @ `4eb6639`) and resolved, so the two should be
reviewed/merged in that order with this PR on top of #96.

Addresses: the request to keep #96 focused on the modern 2FA / session-only
login / reauthentication / aggregated-events core.

## Files changed (9)

- `custom_components/homeassistantedupage/__init__.py`
- `custom_components/homeassistantedupage/homeassistant_edupage.py`
- `custom_components/homeassistantedupage/sensor.py`
- `custom_components/homeassistantedupage/calendar.py`
- `custom_components/homeassistantedupage/manifest.json` (version -> `0.5.0`)
- `custom_components/homeassistantedupage/services.yaml`
- `tests/test_extras.py`
- `tests/test_services.py`
- `tests/test_sensor.py`

## Features added

- **Services**: `homeassistantedupage.choose_meal`,
  `homeassistantedupage.sign_off_meal`, `homeassistantedupage.rate_meal`,
  `homeassistantedupage.send_message` (schemas in `services.yaml`).
- **Sensors**: timetable-changes and missing-teachers substitution sensors,
  next-ringing sensor, and per-term average sensors (1st/2nd term).
- **Calendar**: the canteen calendar with per-day meal lookup.

## Issues addressed

1. **Multi-entry service collision** — services are registered **once,
   globally** (guarded by a `_services_ready` flag) rather than once per config
   entry, so multiple entries no longer overwrite each other's handlers. Each
   call resolves its target coordinator through an optional `entry_id`
   service-data key; an unknown `entry_id` raises instead of acting on the
   wrong account.

2. **`send_message` recipient types** — recipient strings are resolved to
   accounts via `get_students()`/`get_teachers()` by numeric `person_id` or
   case-insensitive name, then handed to `edupage-api` as recipient **IDs**
   (`account.get_id()`) rather than the `EduStudent`/`EduTeacher` objects
   (avoiding the 0.12.5 exact `EduAccount` type check). Unmatched recipients
   raise a clear `UpdateFailed`.

3. **Term-average sensor staleness** — `EduPageTermAverageSensor` reads the
   per-term grades live from `coordinator.data["grades_per_term"][term_key]` on
   every poll, instead of freezing the constructor snapshot at setup.

4. **Canteen time/datetime `TypeError`** — all meal slot values are normalized
   to datetimes. A meal with no `served_from` occupies the whole day as
   midnight → next midnight, so there is no `datetime.time` vs
   `datetime.datetime` comparison and no `TypeError`.

5. **Cross-day next-lesson selection** — the next-lesson comparison uses the
   full `datetime.combine(day, lesson.start_time)`, so a lesson today at 10:00
   is correctly selected ahead of a lesson tomorrow at 08:00.

6. **Bounded notification attributes** — the flat `event_N_*` attributes are
   capped at `_MAX_EVENTS` (50) like the structured `events` list, so state
   attributes cannot grow without limit.

7. **Canteen calendar always created** — the canteen calendar entity is now
   always added; when no menu data is available it simply returns no events.

8. **`EdupageSessionExpired` not swallowed** — `login()` re-raises its own
   expiration signal so the reauthentication flow starts, instead of the broad
   handler converting it to a generic `UpdateFailed`.

## Testing / validation

- Tests added for the meal services, message recipient resolution, service
  coordinator resolution across multiple config entries and `entry_id`,
  canteen serving-time handling, empty menus, term averages (incl. non-numeric
  grades), and the bounded notification attributes.
- All changed files pass `python3 -m py_compile`.
- CI (GitHub Actions `pytest`) is green.
