### PR TITLE
Fix EduPage empty data handling for 0.5.1

### DIFF
--- a/custom_components/homeassistantedupage/__init__.py
+++ b/custom_components/homeassistantedupage/__init__.py
@@ -109,12 +109,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     try:
                         meals = await edupage.get_meals(current_date)
                     except Exception as e:  # noqa: BLE001
-                        _LOGGER.error(
+                        _LOGGER.warning(
                             "Failed to fetch meals data for %s: %s",
                             current_date,
                             e,
                         )
-                        break
+                        continue
                     meals_to_add = []
                     if meals is not None:
                         for meal in (meals.snack, meals.lunch, meals.afternoon_snack):

--- a/custom_components/homeassistantedupage/homeassistant_edupage.py
+++ b/custom_components/homeassistantedupage/homeassistant_edupage.py
@@ -171,16 +171,22 @@ class Edupage:
     async def get_meals(self, day):
         try:
             meals = await self.hass.async_add_executor_job(self.api.get_meals, day)
-            if meals is None:
-                _LOGGER.debug("EDUPAGE meals is None for %s", day)
-            else:
-                _LOGGER.debug("EDUPAGE meals for %s: %s", day, meals)
-            return meals
+            return meals or []
+        except IndexError:
+            _LOGGER.debug(
+                "EDUPAGE get_meals returned invalid/empty data for %s",
+                day,
+            )
+            return []
         except Exception as e:  # noqa: BLE001
-            _LOGGER.error("EDUPAGE error updating get_meals() data for %s: %s", day, e)
+            _LOGGER.error(
+                "EDUPAGE error updating get_meals() data for %s: %s",
+                day,
+                e,
+            )
             raise UpdateFailed(
                 f"EDUPAGE error updating get_meals() data for {day}: {e}"
-            )
+            ) from e
 
     async def get_timetable_changes(self, day):
         try:
@@ -194,13 +200,20 @@ class Edupage:
 
     async def get_missing_teachers(self, day):
         try:
-            return await self.hass.async_add_executor_job(
+            result = await self.hass.async_add_executor_job(
                 self.api.get_missing_teachers, day
             )
+            return result or []
+        except IndexError:
+            _LOGGER.debug(
+                "EDUPAGE get_missing_teachers returned invalid/empty data for %s",
+                day,
+            )
+            return []
         except Exception as e:  # noqa: BLE001
             raise UpdateFailed(
                 f"EDUPAGE error updating get_missing_teachers() data for {day}: {e}"
-            )
+            ) from e
 
     async def get_next_ringing_time(self, day_time):
         try:

--- a/custom_components/homeassistantedupage/manifest.json
+++ b/custom_components/homeassistantedupage/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/rine77/homeassistantedupage/issues",
     "requirements": ["edupage-api==0.12.5", "unidecode"],
-    "version": "0.5.0"
+    "version": "0.5.1"
 }

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -39,7 +39,6 @@ async def async_setup_entry(
     grades_by_subject = group_grades_by_subject(grades)
 
     sensors = []
-    sensors = []
     subject_unique_ids = set()
 
     for subject in subjects:

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -39,18 +39,25 @@ async def async_setup_entry(
     grades_by_subject = group_grades_by_subject(grades)
 
     sensors = []
+    sensors = []
+    subject_unique_ids = set()
 
     for subject in subjects:
         subject_grades = grades_by_subject.get(subject.subject_id, [])
-        sensors.append(
-            EduPageSubjectSensor(
-                coordinator,
-                student.get("id"),
-                student.get("name"),
-                subject.name,
-                subject_grades,
-            )
+
+        sensor = EduPageSubjectSensor(
+            coordinator,
+            student.get("id"),
+            student.get("name"),
+            subject.name,
+            subject_grades,
         )
+
+        if sensor.unique_id in subject_unique_ids:
+            sensor._unique_id = f"{sensor.unique_id}_{subject.subject_id}"
+
+        subject_unique_ids.add(sensor.unique_id)
+        sensors.append(sensor)
 
     sensors.append(
         EduPageNotificationSensor(

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -301,11 +301,11 @@ class EduPageSubstitutionSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def state(self):
-        return len(self.coordinator.data.get(self._data_key, []))
+        return len(self.coordinator.data.get(self._data_key) or [])
 
     @property
     def extra_state_attributes(self):
-        entries = self.coordinator.data.get(self._data_key, [])
+        entries = self.coordinator.data.get(self._data_key) or []
         attributes = {
             "student": self.coordinator.data.get("student", {}),
             "unique_id": self._unique_id,


### PR DESCRIPTION
This PR prepares the 0.5.1 bugfix release.

Changes:

* handle `None` values in substitution sensors
* avoid duplicate subject sensor unique IDs
* handle missing/invalid meal data gracefully
* handle missing teacher data gracefully
* bump integration version to `0.5.1`

Tested with Home Assistant 2026.9.0 using live EduPage data. The integration loads successfully without the previously observed errors.
