### PR TITLE
Fix missing student names and empty meal data for 0.5.2

### DIFF
--- a/custom_components/homeassistantedupage/__init__.py
+++ b/custom_components/homeassistantedupage/__init__.py
@@ -10,18 +10,22 @@ import voluptuous as vol
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .homeassistant_edupage import Edupage, EdupageSessionExpired
-from .const import DOMAIN, CONF_PHPSESSID, CONF_SUBDOMAIN, CONF_STUDENT_ID
 from edupage_api.lunches import MealType
 from edupage_api.grades import Term
+from .const import (
+    DOMAIN,
+    CONF_PHPSESSID,
+    CONF_SUBDOMAIN,
+    CONF_STUDENT_ID,
+    CONF_STUDENT_NAME,
+)
 
 _LOGGER = logging.getLogger("custom_components.homeassistant_edupage")
-
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the integration (config-entry only)."""
     _LOGGER.debug("INIT called async_setup")
     return True
-
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up EduPage integration and validate the stored session."""
@@ -32,6 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     subdomain = entry.data[CONF_SUBDOMAIN]
     phpsessid = entry.data[CONF_PHPSESSID]
     student_id = entry.data[CONF_STUDENT_ID]
+    stored_student_name = entry.data.get(CONF_STUDENT_NAME)
     edupage = Edupage(hass=hass, sessionid=phpsessid)
     coordinator = None
 
@@ -69,6 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     )
                     return {"timetable": {}}
 
+                student_name = student.name or stored_student_name or str(student.person_id)
                 grades = await edupage.get_grades()
                 subjects = await edupage.get_subjects()
                 notifications = await edupage.get_notifications()
@@ -171,7 +177,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     school_year = None
 
                 return_data = {
-                    "student": {"id": student.person_id, "name": student.name},
+                    "student": {"id": student.person_id, "name": student_name},
                     "grades": grades,
                     "subjects": subjects,
                     "timetable": timetable_data,

--- a/custom_components/homeassistantedupage/config_flow.py
+++ b/custom_components/homeassistantedupage/config_flow.py
@@ -184,7 +184,10 @@ class EdupageConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_SUBDOMAIN: user_input[CONF_SUBDOMAIN],
             CONF_PHPSESSID: phpsess,
         }
-        self.students = {student.person_id: student.name for student in students}
+        self.students = {
+            student.person_id: student.name or str(student.person_id)
+            for student in students
+        }
         return await self.async_step_select_student()
 
     async def async_step_select_student(self, user_input=None):

--- a/custom_components/homeassistantedupage/homeassistant_edupage.py
+++ b/custom_components/homeassistantedupage/homeassistant_edupage.py
@@ -171,13 +171,13 @@ class Edupage:
     async def get_meals(self, day):
         try:
             meals = await self.hass.async_add_executor_job(self.api.get_meals, day)
-            return meals or []
+            return meals
         except IndexError:
             _LOGGER.debug(
                 "EDUPAGE get_meals returned invalid/empty data for %s",
                 day,
             )
-            return []
+            return None
         except Exception as e:  # noqa: BLE001
             _LOGGER.error(
                 "EDUPAGE error updating get_meals() data for %s: %s",

--- a/custom_components/homeassistantedupage/manifest.json
+++ b/custom_components/homeassistantedupage/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/rine77/homeassistantedupage/issues",
     "requirements": ["edupage-api==0.12.5", "unidecode"],
-    "version": "0.5.1"
+    "version": "0.5.2"
 }


### PR DESCRIPTION
## Summary

This bugfix addresses two edge cases found after the v0.5.1 release.

### Changes

* Fall back to the student name stored in the config entry when EduPage returns a student without a name
* Fall back to the student ID if no student name is available at all
* Prevent `unidecode()` from receiving a `None` student name during sensor setup
* Handle missing or invalid meal data without aborting the coordinator update
* Ensure new config entries do not store a `None` student name
* Bump integration version to 0.5.2

### Testing

Tested with Home Assistant 2026.9.0 using live EduPage data.

The coordinator now completes successfully when EduPage returns missing meal data or a student without a name.
