### PR TITLE
feat: persist EduPage sensor states across restarts and outages

### DIFF
--- a/custom_components/homeassistantedupage/__init__.py
+++ b/custom_components/homeassistantedupage/__init__.py
@@ -35,29 +35,43 @@ async def _collect_data(edupage, student, student_name):
     source (e.g. a ``get_grades()`` crash) must not discard the rest of the
     data; the failed section falls back to an empty list so timetable,
     calendar, meals and substitution data are still returned.
+
+    Per-section freshness is recorded in the returned ``data_ok`` mapping so
+    sensors can tell whether their own source data was actually refreshed this
+    poll (rather than inferring it from ``coordinator.last_update_success``,
+    which stays ``True`` when only one section fails).
     """
+    data_ok = {}
+
     try:
         grades = await edupage.get_grades()
+        data_ok["grades"] = True
     except Exception as e:  # noqa: BLE001
         _LOGGER.warning("get_grades failed: %s", e)
         grades = []
+        data_ok["grades"] = False
 
     try:
         subjects = await edupage.get_subjects()
+        data_ok["subjects"] = True
     except Exception as e:  # noqa: BLE001
         _LOGGER.warning("get_subjects failed: %s", e)
         subjects = []
+        data_ok["subjects"] = False
 
     try:
         notifications = await edupage.get_notifications()
+        data_ok["notifications"] = True
     except Exception as e:  # noqa: BLE001
         _LOGGER.warning("get_notifications failed: %s", e)
         notifications = []
+        data_ok["notifications"] = False
 
     today = datetime.now().date()
 
     timetable_data = {}
     timetable_data_canceled = {}
+    timetable_ok = False
     for offset in range(14):
         current_date = today + timedelta(days=offset)
         try:
@@ -71,6 +85,7 @@ async def _collect_data(edupage, student, student_name):
                 e,
             )
             break
+        timetable_ok = True
         lessons_to_add = []
         canceled_lessons = []
         if timetable is not None:
@@ -83,8 +98,10 @@ async def _collect_data(edupage, student, student_name):
             timetable_data[current_date] = lessons_to_add
         if canceled_lessons:
             timetable_data_canceled[current_date] = canceled_lessons
+    data_ok["timetable"] = timetable_ok
 
     canteen_menu_data = {}
+    canteen_ok = False
     for offset in range(14):
         current_date = today + timedelta(days=offset)
         try:
@@ -96,6 +113,7 @@ async def _collect_data(edupage, student, student_name):
                 e,
             )
             continue
+        canteen_ok = True
         meals_to_add = []
         if meals is not None:
             for meal in (meals.snack, meals.lunch, meals.afternoon_snack):
@@ -103,38 +121,48 @@ async def _collect_data(edupage, student, student_name):
                     meals_to_add.append(meal)
         if meals_to_add:
             canteen_menu_data[current_date] = meals_to_add
+    data_ok["canteen_menu"] = canteen_ok
 
     # Substitution / ringing extras for sensors.
     try:
         timetable_changes = await edupage.get_timetable_changes(today)
+        data_ok["timetable_changes"] = True
     except Exception as e:  # noqa: BLE001
         _LOGGER.warning(
             "get_timetable_changes failed for %s: %s", today, e
         )
         timetable_changes = []
+        data_ok["timetable_changes"] = False
 
     try:
         missing_teachers = await edupage.get_missing_teachers(today)
+        data_ok["missing_teachers"] = True
     except Exception as e:  # noqa: BLE001
         _LOGGER.warning(
             "get_missing_teachers failed for %s: %s", today, e
         )
         missing_teachers = []
+        data_ok["missing_teachers"] = False
 
     try:
         next_ringing = await edupage.get_next_ringing_time(
             datetime.now()
         )
+        data_ok["next_ringing"] = True
     except Exception as e:  # noqa: BLE001
         _LOGGER.warning("get_next_ringing_time failed: %s", e)
         next_ringing = None
+        data_ok["next_ringing"] = False
 
     # Per-term grades for grade-average sensors.
     school_year = None
     grades_per_term = {}
+    data_ok["grades_per_term"] = False
     try:
         school_year = await edupage.get_school_year()
+        data_ok["school_year"] = school_year is not None
         term_map = {"first": Term.FIRST, "second": Term.SECOND}
+        all_terms_ok = school_year is not None
         for term_key, term_enum in term_map.items():
             try:
                 grades_per_term[
@@ -147,9 +175,12 @@ async def _collect_data(edupage, student, student_name):
                     "get_grades_for_term(%s) failed: %s", term_key, e
                 )
                 grades_per_term[term_key] = []
+                all_terms_ok = False
+        data_ok["grades_per_term"] = all_terms_ok
     except Exception as e:  # noqa: BLE001
         _LOGGER.warning("get_school_year failed: %s", e)
         school_year = None
+        data_ok["school_year"] = False
 
     return {
         "student": {"id": student.person_id, "name": student_name},
@@ -164,6 +195,7 @@ async def _collect_data(edupage, student, student_name):
         "next_ringing": next_ringing,
         "school_year": school_year,
         "grades_per_term": grades_per_term,
+        "data_ok": data_ok,
         "last_updated": datetime.now().isoformat(),
     }
 

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from .const import DOMAIN
+from .const import CONF_STUDENT_ID, CONF_STUDENT_NAME, DOMAIN
 
 _LOGGER = logging.getLogger("custom_components.homeassistant_edupage")
 
@@ -124,6 +124,18 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
     student = coordinator.data.get("student", {})
+
+    # Fall back to the stored student from the config entry when the first
+    # coordinator refresh has not produced student data (e.g. EduPage was
+    # unavailable at HA startup). Without this, construction would pass a
+    # None name into unidecode() and abort before RestoreEntity is attached.
+    student_id = student.get("id") if student else entry.data.get(CONF_STUDENT_ID)
+    student_name = (
+        student.get("name")
+        if student and student.get("name")
+        else entry.data.get(CONF_STUDENT_NAME)
+    )
+
     subjects = coordinator.data.get("subjects", [])
     grades = coordinator.data.get("grades", [])
     notifications = coordinator.data.get("notifications", [])
@@ -137,9 +149,10 @@ async def async_setup_entry(
 
         sensor = EduPageSubjectSensor(
             coordinator,
-            student.get("id"),
-            student.get("name"),
+            student_id,
+            student_name,
             subject.name,
+            subject.subject_id,
             subject_grades,
         )
 
@@ -151,35 +164,35 @@ async def async_setup_entry(
 
     sensors.append(
         EduPageNotificationSensor(
-            coordinator, student.get("id"), student.get("name"), notifications
+            coordinator, student_id, student_name, notifications
         )
     )
     sensors.append(
         EduPageSubstitutionSensor(
-            coordinator, student.get("id"), student.get("name"), "timetable_changes"
+            coordinator, student_id, student_name, "timetable_changes"
         )
     )
     sensors.append(
         EduPageSubstitutionSensor(
-            coordinator, student.get("id"), student.get("name"), "missing_teachers"
+            coordinator, student_id, student_name, "missing_teachers"
         )
     )
     sensors.append(
-        EduPageRingingSensor(coordinator, student.get("id"), student.get("name"))
+        EduPageRingingSensor(coordinator, student_id, student_name)
     )
     sensors.append(
         EduPageTermAverageSensor(
             coordinator,
-            student.get("id"),
-            student.get("name"),
+            student_id,
+            student_name,
             term_key="first",
         )
     )
     sensors.append(
         EduPageTermAverageSensor(
             coordinator,
-            student.get("id"),
-            student.get("name"),
+            student_id,
+            student_name,
             term_key="second",
         )
     )
@@ -197,13 +210,14 @@ class EduPageSubjectSensor(StateRestoringSensor):
         except (TypeError, ValueError):
             return None
 
-    def __init__(self, coordinator, student_id, student_name, subject_name, grades=None):
+    def __init__(self, coordinator, student_id, student_name, subject_name, subject_id, grades=None):
         """Initialize the sensor."""
         super().__init__(coordinator)
 
         self._student_id = student_id
         self._student_name = unidecode(student_name).replace(" ", "_").lower()
         self._subject_name = unidecode(subject_name).replace(" ", "_").lower()
+        self._subject_id = subject_id
         self._grades = grades or []
 
         self._attr_name = f"Edupage - {student_name} - {subject_name}"
@@ -217,10 +231,20 @@ class EduPageSubjectSensor(StateRestoringSensor):
         return self._unique_id
 
     @property
+    def _current_grades(self):
+        """Return live grades for this subject from the coordinator."""
+        all_grades = self.coordinator.data.get("grades", [])
+        if self._subject_id is None:
+            return self._grades
+        return [
+            g for g in all_grades if getattr(g, "subject_id", None) == self._subject_id
+        ]
+
+    @property
     def state(self):
         """Return the grade count, falling back to the last-known value."""
         if self._data_is_fresh():
-            return self._set_value(len(self._grades))
+            return self._set_value(len(self._current_grades))
         if self._last_value is not None:
             return self._last_value
         return 0
@@ -228,7 +252,8 @@ class EduPageSubjectSensor(StateRestoringSensor):
     @property
     def extra_state_attributes(self):
         """Return additional attributes."""
-        if not self._grades:
+        current_grades = self._current_grades
+        if not current_grades:
             attributes = {"info": "no grades yet"}
         else:
             attributes = {
@@ -236,7 +261,7 @@ class EduPageSubjectSensor(StateRestoringSensor):
                 "unique_id": self._unique_id,
             }
 
-            for i, grade in enumerate(self._grades):
+            for i, grade in enumerate(current_grades):
                 attributes[f"grade_{i+1}_title"] = grade.title
                 attributes[f"grade_{i+1}_grade_n"] = grade.grade_n
                 if grade.max_points:

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -97,10 +97,14 @@ class StateRestoringSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
 
     @property
     def available(self):
-        """Stay available while we can still show a last-known value."""
-        if self._last_value is not None:
-            return True
-        return super().available
+        """Follow this sensor's own freshness, not just the whole coordinator.
+
+        A sensor stays available when its own data section refreshed, or while
+        it can still show a last-known value. When its section failed and there
+        is no restored/last-known value to fall back on, it must be unavailable
+        even if the overall coordinator update succeeded.
+        """
+        return self._data_is_fresh() or self._last_value is not None
 
     @property
     def data_stale(self):

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -47,12 +47,28 @@ class StateRestoringSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
         self._apply_restored(await self.async_get_last_state())
 
     def _apply_restored(self, last_state):
-        """Apply a recorder-restored state as the initial last-known value."""
+        """Apply a recorder-restored state as the initial last-known value.
+
+        Non-restorable restored states (``unknown``/``unavailable``/``none``)
+        are ignored, leaving ``_last_value`` as ``None`` so the sensor stays
+        unavailable rather than showing an unbacked value.
+        """
         if last_state is not None:
             self._last_value = self._coerce_restored(last_state.state)
 
     def _coerce_restored(self, raw_state):
-        """Convert a recorder-restored string state back to the native type."""
+        """Convert a recorder-restored string state back to the native type.
+
+        Returns ``None`` for non-restorable states so the entity does not
+        surface ``unknown``/``unavailable`` (or an invented ``0``) as a real
+        last-known value.
+        """
+        if raw_state is None or not raw_state or raw_state in (
+            "unknown",
+            "unavailable",
+            "none",
+        ):
+            return None
         return raw_state
 
     def _set_value(self, fresh_value):
@@ -161,7 +177,7 @@ class EduPageSubjectSensor(StateRestoringSensor):
         try:
             return int(float(raw_state))
         except (TypeError, ValueError):
-            return 0
+            return None
 
     def __init__(self, coordinator, student_id, student_name, subject_name, grades=None):
         """Initialize the sensor."""
@@ -230,7 +246,7 @@ class EduPageNotificationSensor(StateRestoringSensor):
         try:
             return int(float(raw_state))
         except (TypeError, ValueError):
-            return 0
+            return None
 
     def __init__(self, coordinator, student_id, student_name, notifications):
         """Initialize the sensor."""
@@ -369,7 +385,7 @@ class EduPageSubstitutionSensor(StateRestoringSensor):
         try:
             return int(float(raw_state))
         except (TypeError, ValueError):
-            return 0
+            return None
 
     def __init__(self, coordinator, student_id, student_name, data_key):
         """data_key is 'timetable_changes' or 'missing_teachers'."""
@@ -509,7 +525,7 @@ class EduPageTermAverageSensor(StateRestoringSensor):
         try:
             return round(float(raw_state), 2)
         except (TypeError, ValueError):
-            return "unknown"
+            return None
 
     @property
     def state(self):

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 
@@ -15,6 +16,62 @@ _LOGGER = logging.getLogger("custom_components.homeassistant_edupage")
 # Bound on the number of events exposed in the "events" state attribute, to
 # keep stored state attributes from growing without limit over time.
 _MAX_EVENTS = 50
+
+
+def _has_fresh_data(coordinator):
+    """True once the coordinator has completed a successful refresh."""
+    return coordinator.last_update_success and bool(coordinator.data)
+
+
+class StateRestoringSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
+    """Base class that keeps sensor states stable across restarts and outages.
+
+    On startup the previous state is restored from the recorder and used as a
+    seed while the coordinator is still fetching its first data. After that the
+    entity keeps an in-memory ``_last_value`` that is refreshed on every
+    successful coordinator update, so during a subsequent EduPage outage it
+    keeps exposing the most recent value instead of dropping to 0/unknown.
+
+    Availability is intentionally __not__ tied to the coordinator alone: the
+    entity stays ``available`` while it holds a last-known value, so dashboards
+    can keep showing it during an outage. The ``data_stale`` attribute is set to
+    ``True`` whenever the exposed value is not backed by a fresh coordinator
+    update, so automations can avoid acting on stale data.
+    """
+
+    _last_value = None
+
+    async def async_added_to_hass(self) -> None:
+        """Seed the last-known value from the recorder before any update."""
+        await super().async_added_to_hass()
+        self._apply_restored(await self.async_get_last_state())
+
+    def _apply_restored(self, last_state):
+        """Apply a recorder-restored state as the initial last-known value."""
+        if last_state is not None:
+            self._last_value = self._coerce_restored(last_state.state)
+
+    def _coerce_restored(self, raw_state):
+        """Convert a recorder-restored string state back to the native type."""
+        return raw_state
+
+    def _set_value(self, fresh_value):
+        """Remember the freshest value and return it as the current state."""
+        if fresh_value is not None:
+            self._last_value = fresh_value
+        return fresh_value
+
+    @property
+    def available(self):
+        """Stay available while we can still show a last-known value."""
+        if self._last_value is not None:
+            return True
+        return super().available
+
+    @property
+    def data_stale(self):
+        """True when the exposed value is not from a fresh coordinator update."""
+        return not _has_fresh_data(self.coordinator)
 
 
 def group_grades_by_subject(grades):
@@ -96,8 +153,15 @@ async def async_setup_entry(
     async_add_entities(sensors, True)
 
 
-class EduPageSubjectSensor(CoordinatorEntity, SensorEntity):
+class EduPageSubjectSensor(StateRestoringSensor):
     """Subject sensor entity for a specific student."""
+
+    def _coerce_restored(self, raw_state):
+        """Restore the grade count as an int when possible."""
+        try:
+            return int(float(raw_state))
+        except (TypeError, ValueError):
+            return 0
 
     def __init__(self, coordinator, student_id, student_name, subject_name, grades=None):
         """Initialize the sensor."""
@@ -120,41 +184,53 @@ class EduPageSubjectSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def state(self):
-        """Return the grade count."""
-        return len(self._grades)
+        """Return the grade count, falling back to the last-known value."""
+        if _has_fresh_data(self.coordinator):
+            return self._set_value(len(self._grades))
+        if self._last_value is not None:
+            return self._last_value
+        return 0
 
     @property
     def extra_state_attributes(self):
         """Return additional attributes."""
         if not self._grades:
-            return {"info": "no grades yet"}
+            attributes = {"info": "no grades yet"}
+        else:
+            attributes = {
+                "student": self.coordinator.data.get("student", {}),
+                "unique_id": self._unique_id,
+            }
 
-        attributes = {
-            "student": self.coordinator.data.get("student", {}),
-            "unique_id": self._unique_id,
-        }
+            for i, grade in enumerate(self._grades):
+                attributes[f"grade_{i+1}_title"] = grade.title
+                attributes[f"grade_{i+1}_grade_n"] = grade.grade_n
+                if grade.max_points:
+                    attributes[f"grade_{i+1}_max_points"] = grade.max_points
+                if grade.class_grade_avg:
+                    attributes[f"grade_{i+1}_class_avg_grade"] = grade.class_grade_avg
+                if grade.percent:
+                    attributes[f"grade_{i+1}_percent"] = grade.percent
+                if grade.comment:
+                    attributes[f"grade_{i+1}_comment"] = grade.comment
+                attributes[f"grade_{i+1}_date"] = grade.date.strftime("%Y-%m-%d %H:%M:%S")
 
-        for i, grade in enumerate(self._grades):
-            attributes[f"grade_{i+1}_title"] = grade.title
-            attributes[f"grade_{i+1}_grade_n"] = grade.grade_n
-            if grade.max_points:
-                attributes[f"grade_{i+1}_max_points"] = grade.max_points
-            if grade.class_grade_avg:
-                attributes[f"grade_{i+1}_class_avg_grade"] = grade.class_grade_avg
-            if grade.percent:
-                attributes[f"grade_{i+1}_percent"] = grade.percent
-            if grade.comment:
-                attributes[f"grade_{i+1}_comment"] = grade.comment
-            attributes[f"grade_{i+1}_date"] = grade.date.strftime("%Y-%m-%d %H:%M:%S")
+                teacher_name = grade.teacher.name if grade.teacher else "unknown"
+                attributes[f"grade_{i+1}_teacher"] = teacher_name
 
-            teacher_name = grade.teacher.name if grade.teacher else "unknown"
-            attributes[f"grade_{i+1}_teacher"] = teacher_name
-
+        attributes["data_stale"] = self.data_stale
         return attributes
 
 
-class EduPageNotificationSensor(CoordinatorEntity, SensorEntity):
+class EduPageNotificationSensor(StateRestoringSensor):
     """Notification sensor for a specific student (counts all event types)."""
+
+    def _coerce_restored(self, raw_state):
+        """Restore the notification count as an int when possible."""
+        try:
+            return int(float(raw_state))
+        except (TypeError, ValueError):
+            return 0
 
     def __init__(self, coordinator, student_id, student_name, notifications):
         """Initialize the sensor."""
@@ -181,8 +257,12 @@ class EduPageNotificationSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def state(self):
-        """Return state."""
-        return len(self._current_notifications)
+        """Return state, falling back to the last-known value."""
+        if _has_fresh_data(self.coordinator):
+            return self._set_value(len(self._current_notifications))
+        if self._last_value is not None:
+            return self._last_value
+        return 0
 
     @property
     def extra_state_attributes(self):
@@ -249,6 +329,7 @@ class EduPageNotificationSensor(CoordinatorEntity, SensorEntity):
                 )
                 attributes[f"event_{i+1}_author"] = author_name
 
+        attributes["data_stale"] = self.data_stale
         return attributes
 
     def _subject_name_by_id(self, subject_id):
@@ -280,8 +361,15 @@ def _average(grades):
     return round(sum(values) / len(values), 2) if values else None
 
 
-class EduPageSubstitutionSensor(CoordinatorEntity, SensorEntity):
+class EduPageSubstitutionSensor(StateRestoringSensor):
     """Sensor for timetable changes or missing teachers for the current day."""
+
+    def _coerce_restored(self, raw_state):
+        """Restore the substitution count as an int when possible."""
+        try:
+            return int(float(raw_state))
+        except (TypeError, ValueError):
+            return 0
 
     def __init__(self, coordinator, student_id, student_name, data_key):
         """data_key is 'timetable_changes' or 'missing_teachers'."""
@@ -307,7 +395,13 @@ class EduPageSubstitutionSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def state(self):
-        return len(self.coordinator.data.get(self._data_key) or [])
+        if _has_fresh_data(self.coordinator):
+            return self._set_value(
+                len(self.coordinator.data.get(self._data_key) or [])
+            )
+        if self._last_value is not None:
+            return self._last_value
+        return 0
 
     @property
     def extra_state_attributes(self):
@@ -329,10 +423,11 @@ class EduPageSubstitutionSensor(CoordinatorEntity, SensorEntity):
             for i, teacher in enumerate(entries):
                 attributes[f"teacher_{i+1}_name"] = teacher.name
                 attributes[f"teacher_{i+1}_id"] = teacher.person_id
+        attributes["data_stale"] = self.data_stale
         return attributes
 
 
-class EduPageRingingSensor(CoordinatorEntity, SensorEntity):
+class EduPageRingingSensor(StateRestoringSensor):
     """Sensor exposing the next school-bell ringing time."""
 
     def __init__(self, coordinator, student_id, student_name):
@@ -351,9 +446,13 @@ class EduPageRingingSensor(CoordinatorEntity, SensorEntity):
     @property
     def state(self):
         ringing = self.coordinator.data.get("next_ringing")
-        if ringing is None:
-            return "unknown"
-        return ringing.time.strftime("%H:%M")
+        if _has_fresh_data(self.coordinator):
+            if ringing is None:
+                return self._set_value("unknown")
+            return self._set_value(ringing.time.strftime("%H:%M"))
+        if self._last_value is not None:
+            return self._last_value
+        return "unknown"
 
     @property
     def extra_state_attributes(self):
@@ -366,10 +465,11 @@ class EduPageRingingSensor(CoordinatorEntity, SensorEntity):
             attrs["ringing_type"] = ringing.type.name
             attrs["time"] = ringing.time.strftime("%H:%M")
             attrs["date"] = datetime.now().strftime("%Y-%m-%d")
+        attrs["data_stale"] = self.data_stale
         return attrs
 
 
-class EduPageTermAverageSensor(CoordinatorEntity, SensorEntity):
+class EduPageTermAverageSensor(StateRestoringSensor):
     """Sensor showing grade count and average for a specific school term.
 
     Reads the per-term grades live from the coordinator each poll, so the
@@ -404,10 +504,21 @@ class EduPageTermAverageSensor(CoordinatorEntity, SensorEntity):
     def _school_year(self):
         return self.coordinator.data.get("school_year")
 
+    def _coerce_restored(self, raw_state):
+        """Restore the term average as a float when possible."""
+        try:
+            return round(float(raw_state), 2)
+        except (TypeError, ValueError):
+            return "unknown"
+
     @property
     def state(self):
-        avg = _average(self._current_grades)
-        return avg if avg is not None else "unknown"
+        if _has_fresh_data(self.coordinator):
+            avg = _average(self._current_grades)
+            return self._set_value(avg if avg is not None else "unknown")
+        if self._last_value is not None:
+            return self._last_value
+        return "unknown"
 
     @property
     def extra_state_attributes(self):
@@ -429,4 +540,5 @@ class EduPageTermAverageSensor(CoordinatorEntity, SensorEntity):
             "grade_count": len(grades),
             "grade_average": _average(grades),
             "subject_averages": subject_averages,
+            "data_stale": self.data_stale,
         }

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -18,9 +18,20 @@ _LOGGER = logging.getLogger("custom_components.homeassistant_edupage")
 _MAX_EVENTS = 50
 
 
-def _has_fresh_data(coordinator):
-    """True once the coordinator has completed a successful refresh."""
-    return coordinator.last_update_success and bool(coordinator.data)
+def _section_fresh(coordinator, key):
+    """True when a specific data section was successfully refreshed.
+
+    With partial coordinator failures (#109) ``last_update_success`` stays
+    ``True`` even when one source (e.g. grades) failed and fell back to an
+    empty list. Each sensor tracks its own section via the ``data_ok`` map
+    produced by ``_collect_data`` so it does not mistake a failed section for
+    fresh data.
+    """
+    if not coordinator.last_update_success or not coordinator.data:
+        return False
+    return bool(
+        coordinator.data.get("data_ok", {}).get(key, True),
+    )
 
 
 class StateRestoringSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
@@ -35,9 +46,12 @@ class StateRestoringSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
     Availability is intentionally __not__ tied to the coordinator alone: the
     entity stays ``available`` while it holds a last-known value, so dashboards
     can keep showing it during an outage. The ``data_stale`` attribute is set to
-    ``True`` whenever the exposed value is not backed by a fresh coordinator
-    update, so automations can avoid acting on stale data.
+    ``True`` whenever the exposed value is not backed by a fresh update of this
+    sensor's own data section, so automations can avoid acting on stale data.
     """
+
+    #: Key (in ``coordinator.data`` / ``data_ok``) identifying this sensor's data.
+    _data_key = "grades"
 
     _last_value = None
 
@@ -77,6 +91,10 @@ class StateRestoringSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
             self._last_value = fresh_value
         return fresh_value
 
+    def _data_is_fresh(self):
+        """True when this sensor's own data section was refreshed."""
+        return _section_fresh(self.coordinator, self._data_key)
+
     @property
     def available(self):
         """Stay available while we can still show a last-known value."""
@@ -87,7 +105,7 @@ class StateRestoringSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
     @property
     def data_stale(self):
         """True when the exposed value is not from a fresh coordinator update."""
-        return not _has_fresh_data(self.coordinator)
+        return not self._data_is_fresh()
 
 
 def group_grades_by_subject(grades):
@@ -201,7 +219,7 @@ class EduPageSubjectSensor(StateRestoringSensor):
     @property
     def state(self):
         """Return the grade count, falling back to the last-known value."""
-        if _has_fresh_data(self.coordinator):
+        if self._data_is_fresh():
             return self._set_value(len(self._grades))
         if self._last_value is not None:
             return self._last_value
@@ -252,6 +270,7 @@ class EduPageNotificationSensor(StateRestoringSensor):
         """Initialize the sensor."""
         super().__init__(coordinator)
 
+        self._data_key = "notifications"
         self._notifications = notifications
         self._student_id = student_id
         self._student_name = unidecode(student_name).replace(" ", "_").lower()
@@ -274,7 +293,7 @@ class EduPageNotificationSensor(StateRestoringSensor):
     @property
     def state(self):
         """Return state, falling back to the last-known value."""
-        if _has_fresh_data(self.coordinator):
+        if self._data_is_fresh():
             return self._set_value(len(self._current_notifications))
         if self._last_value is not None:
             return self._last_value
@@ -411,7 +430,7 @@ class EduPageSubstitutionSensor(StateRestoringSensor):
 
     @property
     def state(self):
-        if _has_fresh_data(self.coordinator):
+        if self._data_is_fresh():
             return self._set_value(
                 len(self.coordinator.data.get(self._data_key) or [])
             )
@@ -448,6 +467,7 @@ class EduPageRingingSensor(StateRestoringSensor):
 
     def __init__(self, coordinator, student_id, student_name):
         super().__init__(coordinator)
+        self._data_key = "next_ringing"
         self._student_id = student_id
         self._student_name = _subject_slug(student_name)
         self._attr_name = f"Edupage - Next Ringing {student_name}"
@@ -462,7 +482,7 @@ class EduPageRingingSensor(StateRestoringSensor):
     @property
     def state(self):
         ringing = self.coordinator.data.get("next_ringing")
-        if _has_fresh_data(self.coordinator):
+        if self._data_is_fresh():
             if ringing is None:
                 return self._set_value("unknown")
             return self._set_value(ringing.time.strftime("%H:%M"))
@@ -495,6 +515,7 @@ class EduPageTermAverageSensor(StateRestoringSensor):
 
     def __init__(self, coordinator, student_id, student_name, term_key):
         super().__init__(coordinator)
+        self._data_key = "grades_per_term"
         self._student_id = student_id
         self._student_name = _subject_slug(student_name)
         self._term_key = term_key
@@ -529,7 +550,7 @@ class EduPageTermAverageSensor(StateRestoringSensor):
 
     @property
     def state(self):
-        if _has_fresh_data(self.coordinator):
+        if self._data_is_fresh():
             avg = _average(self._current_grades)
             return self._set_value(avg if avg is not None else "unknown")
         if self._last_value is not None:

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -302,3 +302,35 @@ async def test_collect_data_preserves_student_when_only_grades_fail():
     assert data["grades"] == []
     assert isinstance(data["timetable"], dict)
     assert isinstance(data["canteen_menu"], dict)
+
+
+async def test_collect_data_records_per_section_freshness():
+    """A grades failure sets data_ok['grades']=False while other sections are ok."""
+    edupage = _edupage_with_grades_failing()
+    data = await _collect_data(edupage, _OkStudent(), "Max")
+
+    ok = data["data_ok"]
+    assert ok["grades"] is False
+    assert ok["subjects"] is True
+    assert ok["notifications"] is True
+    assert ok["timetable"] is True
+    assert ok["canteen_menu"] is True  # get_meals returned None (success, just empty)
+    assert ok["timetable_changes"] is True
+    assert ok["missing_teachers"] is True
+    assert ok["next_ringing"] is True
+    assert ok["school_year"] is False  # get_school_year returned None
+    assert ok["grades_per_term"] is False
+
+
+async def test_collect_data_records_all_sections_ok_when_nothing_fails():
+    edupage = _edupage_with_grades_failing()
+    edupage.get_grades = AsyncMock(return_value=[])
+    edupage.get_school_year = AsyncMock(return_value=2025)
+    edupage.get_grades_for_term = AsyncMock(return_value=[])
+
+    data = await _collect_data(edupage, _OkStudent(), "Max")
+
+    ok = data["data_ok"]
+    assert ok["grades"] is True
+    assert ok["school_year"] is True
+    assert ok["grades_per_term"] is True

--- a/tests/test_restore_state.py
+++ b/tests/test_restore_state.py
@@ -429,7 +429,11 @@ async def test_setup_uses_stored_student_when_first_refresh_fails(hass, coord):
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coord
 
     added = []
-    await async_setup_entry(hass, entry, added.append)
+
+    def _add_entities(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, _add_entities)
 
     assert added, "expected at least the notification sensor to be created"
     # Construction succeeded (no unidecode(None)); the stored name survives.

--- a/tests/test_restore_state.py
+++ b/tests/test_restore_state.py
@@ -410,6 +410,7 @@ async def test_setup_uses_stored_student_when_first_refresh_fails(hass, coord):
 
     entry = ConfigEntry(
         version=1,
+        minor_version=1,
         domain=DOMAIN,
         title="Edupage (Max)",
         data={
@@ -421,6 +422,9 @@ async def test_setup_uses_stored_student_when_first_refresh_fails(hass, coord):
         },
         source="user",
         entry_id="entry-fallback",
+        unique_id="unique-fallback",
+        discovery_keys=set(),
+        options={},
     )
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coord
 

--- a/tests/test_restore_state.py
+++ b/tests/test_restore_state.py
@@ -1,0 +1,257 @@
+"""Tests for the RestoreEntity-based state persistence added to the sensors.
+
+These cover the semantics of ``StateRestoringSensor``:
+
+* restoring a value after startup;
+* startup without a previously stored state;
+* replacing the restored value after a successful update;
+* an outage after a successful update;
+* the ``available`` behavior during an outage;
+* preservation of the appropriate state types (counts int, averages float,
+  ringing times string).
+
+The ``hass`` fixture and a live ``DataUpdateCoordinator`` are used, mirroring
+``test_sensor.py``. The restore seed is applied through ``_apply_restored``
+(which ``async_added_to_hass`` delegates to) so the tests exercise the exact
+coercion/restore logic without needing recorder/platform plumbing.
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from custom_components.homeassistantedupage.sensor import (
+    EduPageNotificationSensor,
+    EduPageRingingSensor,
+    EduPageSubjectSensor,
+    EduPageSubstitutionSensor,
+    EduPageTermAverageSensor,
+)
+
+
+class _FakeState:
+    """A minimal recorder-restored State (only ``.state`` is read)."""
+
+    def __init__(self, state):
+        self.state = state
+
+
+class _Grade:
+    def __init__(self, grade_n, subject_name="Maths"):
+        self.grade_n = grade_n
+        self.subject_name = subject_name
+
+
+class _Ringing:
+    def __init__(self, time):
+        self.time = time
+
+    class _Type:
+        name = "bell"
+
+    type = _Type()
+
+
+@pytest.fixture
+def coord(hass: HomeAssistant):
+    """A coordinator whose data and freshness we control directly."""
+    c = DataUpdateCoordinator(hass, logging.getLogger("test"), name="test")
+    c.data = {
+        "student": {"id": 1, "name": "Max"},
+        "subjects": [],
+        "notifications": [],
+        "timetable_changes": [],
+        "missing_teachers": [],
+        "next_ringing": None,
+        "grades_per_term": {"first": [], "second": []},
+    }
+    c.last_update_success = True
+    return c
+
+
+def _subject_sensor(coord):
+    return EduPageSubjectSensor(coord, 1, "Max Kov", "Maths", [])
+
+
+def _notification_sensor(coord):
+    return EduPageNotificationSensor(coord, 1, "Max Kov", [])
+
+
+def _substitution_sensor(coord):
+    return EduPageSubstitutionSensor(coord, 1, "Max Kov", "timetable_changes")
+
+
+def _ringing_sensor(coord):
+    return EduPageRingingSensor(coord, 1, "Max Kov")
+
+
+def _term_sensor(coord, term_key="first"):
+    return EduPageTermAverageSensor(coord, 1, "Max Kov", term_key)
+
+
+def _outage(coord):
+    coord.last_update_success = False
+
+
+def _recover(coord):
+    coord.last_update_success = True
+
+
+# ---------------------------------------------------------------------------
+# Restore after startup
+# ---------------------------------------------------------------------------
+
+
+async def test_restores_value_after_startup(hass, coord):
+    sensor = _subject_sensor(coord)
+    sensor._apply_restored(_FakeState("4"))
+    # No fresh data yet (coordinator refresh not completed).
+    _outage(coord)
+    assert sensor.state == 4
+    assert isinstance(sensor.state, int)
+
+
+async def test_outage_before_any_value_returns_zero(hass, coord):
+    sensor = _subject_sensor(coord)
+    _outage(coord)
+    # No restored state and no fresh data yet.
+    assert sensor.state == 0
+
+
+async def test_restores_after_outage_with_tolerated_empty_data(hass, coord):
+    sensor = _substitution_sensor(coord)
+    sensor._apply_restored(_FakeState("3"))
+    _outage(coord)
+    assert sensor.state == 3
+    assert isinstance(sensor.state, int)
+
+
+# ---------------------------------------------------------------------------
+# Replacing the restored value after a successful update
+# ---------------------------------------------------------------------------
+
+
+async def test_fresh_value_replaces_restored_value(hass, coord):
+    sensor = _subject_sensor(coord)
+    sensor._apply_restored(_FakeState("5"))
+    # A successful update yields a different value.
+    coord.data["grades"] = [_Grade(1), _Grade(2)]
+    sensor._grades = coord.data["grades"]
+    assert sensor.state == 2
+    # Now an outage: the restored value 5 must NOT come back; 2 is current.
+    _outage(coord)
+    assert sensor.state == 2
+
+
+# ---------------------------------------------------------------------------
+# Outage after a successful update
+# ---------------------------------------------------------------------------
+
+
+async def test_outage_keeps_last_known_value(hass, coord):
+    sensor = _notification_sensor(coord)
+    assert sensor.state == 0
+    coord.data["notifications"] = [1, 2, 3]
+    assert sensor.state == 3
+    _outage(coord)
+    assert sensor.state == 3
+
+
+async def test_outage_after_recovery_from_stale(hass, coord):
+    sensor = _substitution_sensor(coord)
+    sensor._apply_restored(_FakeState("3"))
+    _outage(coord)
+    assert sensor.state == 3
+    # Recovery brings a real value that becomes the new last-known.
+    _recover(coord)
+    assert sensor.state == 0
+    assert sensor.state == 0
+    _outage(coord)
+    assert sensor.state == 0
+
+
+# ---------------------------------------------------------------------------
+# Availability during an outage
+# ---------------------------------------------------------------------------
+
+
+async def test_available_while_holding_last_known_value(hass, coord):
+    sensor = _notification_sensor(coord)
+    assert sensor.state == 0
+    _outage(coord)
+    # Keeps holding the last-known value -> stays available and marked stale.
+    assert sensor.available is True
+    assert sensor.data_stale is True
+
+
+async def test_data_stale_attribute_when_fresh(hass, coord):
+    sensor = _substitution_sensor(coord)
+    _recover(coord)
+    assert sensor.data_stale is False
+    attrs = sensor.extra_state_attributes
+    assert attrs["data_stale"] is False
+    _outage(coord)
+    assert sensor.data_stale is True
+    assert sensor.extra_state_attributes["data_stale"] is True
+
+
+async def test_unavailable_with_no_value_and_no_fresh_data(hass, coord):
+    sensor = _subject_sensor(coord)
+    _outage(coord)
+    # Never had a value and no fresh data -> coordinator availability governs.
+    assert sensor.available is False
+
+
+# ---------------------------------------------------------------------------
+# State type preservation
+# ---------------------------------------------------------------------------
+
+
+async def test_subject_and_notification_counts_are_ints(hass, coord):
+    subject = _subject_sensor(coord)
+    subject._apply_restored(_FakeState("3"))
+    _outage(coord)
+    assert isinstance(subject.state, int)
+
+    notif = _notification_sensor(coord)
+    notif._apply_restored(_FakeState("7"))
+    _outage(coord)
+    assert isinstance(notif.state, int)
+
+
+async def test_ringing_time_is_string(hass, coord):
+    sensor = _ringing_sensor(coord)
+    coord.data["next_ringing"] = _Ringing(datetime(2026, 9, 3, 8, 15))
+    assert sensor.state == "08:15"
+    assert isinstance(sensor.state, str)
+    _outage(coord)
+    assert sensor.state == "08:15"
+    assert isinstance(sensor.state, str)
+
+
+async def test_ringing_no_ring_is_unknown(hass, coord):
+    sensor = _ringing_sensor(coord)
+    coord.data["next_ringing"] = None
+    assert sensor.state == "unknown"
+    _outage(coord)
+    assert sensor.state == "unknown"
+
+
+async def test_term_average_is_float(hass, coord):
+    sensor = _term_sensor(coord)
+    coord.data["grades_per_term"]["first"] = [_Grade(1), _Grade(2)]
+    value = sensor.state
+    assert isinstance(value, float)
+    _outage(coord)
+    assert sensor.state == value
+
+
+async def test_term_average_restored_as_float(hass, coord):
+    sensor = _term_sensor(coord, term_key="second")
+    sensor._apply_restored(_FakeState("2.5"))
+    _outage(coord)
+    assert sensor.state == 2.5
+    assert isinstance(sensor.state, float)

--- a/tests/test_restore_state.py
+++ b/tests/test_restore_state.py
@@ -23,7 +23,13 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from custom_components.homeassistantedupage.const import (
+    CONF_STUDENT_ID,
+    CONF_STUDENT_NAME,
+    DOMAIN,
+)
 from custom_components.homeassistantedupage.sensor import (
+    async_setup_entry,
     EduPageNotificationSensor,
     EduPageRingingSensor,
     EduPageSubjectSensor,
@@ -40,9 +46,10 @@ class _FakeState:
 
 
 class _Grade:
-    def __init__(self, grade_n, subject_name="Maths"):
+    def __init__(self, grade_n, subject_name="Maths", subject_id=1):
         self.grade_n = grade_n
         self.subject_name = subject_name
+        self.subject_id = subject_id
 
 
 class _Ringing:
@@ -72,8 +79,9 @@ def coord(hass: HomeAssistant):
     return c
 
 
-def _subject_sensor(coord):
-    return EduPageSubjectSensor(coord, 1, "Max Kov", "Maths", [])
+def _subject_sensor(coord, grades=None):
+    coord.data["grades"] = grades if grades is not None else []
+    return EduPageSubjectSensor(coord, 1, "Max Kov", "Maths", 1, grades or [])
 
 
 def _notification_sensor(coord):
@@ -137,13 +145,35 @@ async def test_restores_after_outage_with_tolerated_empty_data(hass, coord):
 async def test_fresh_value_replaces_restored_value(hass, coord):
     sensor = _subject_sensor(coord)
     sensor._apply_restored(_FakeState("5"))
-    # A successful update yields a different value.
+    # A successful update yields a different value (read live from coordinator).
     coord.data["grades"] = [_Grade(1), _Grade(2)]
-    sensor._grades = coord.data["grades"]
     assert sensor.state == 2
     # Now an outage: the restored value 5 must NOT come back; 2 is current.
     _outage(coord)
     assert sensor.state == 2
+
+
+async def test_later_successful_refresh_updates_subject_grades(hass, coord):
+    """The subject sensor must observe a later successful refresh that replaces
+    coordinator grade data with new grades (no private attribute touch)."""
+    sensor = _subject_sensor(coord, [_Grade(1, subject_id=1)])
+    _set_data_ok(coord, grades=True)
+    assert sensor.state == 1
+
+    # New grades arrive on a later successful poll, including another subject
+    # that this sensor must ignore.
+    coord.data["grades"] = [
+        _Grade(2, subject_name="Maths", subject_id=1),
+        _Grade(3, subject_name="Maths", subject_id=1),
+        _Grade(4, subject_name="English", subject_id=1),
+        _Grade(9, subject_name="Other", subject_id=99),
+    ]
+    _set_data_ok(coord, grades=True)
+    assert sensor.state == 3
+
+    # The per-subject attribute list also tracks the live data.
+    assert len(sensor._current_grades) == 3
+
 
 
 # ---------------------------------------------------------------------------
@@ -317,12 +347,13 @@ def _set_data_ok(coord, **sections):
 async def test_grade_section_failure_keeps_last_value(hass, coord):
     """When grades fail (#109) but the rest of the poll succeeds, the subject
     sensor must not treat its data as fresh or reset to 0."""
-    sensor = EduPageSubjectSensor(coord, 1, "Max Kov", "Maths", [_Grade(1), _Grade(2), _Grade(3)])
+    sensor = _subject_sensor(coord, [_Grade(1), _Grade(2), _Grade(3)])
     # A good poll: grades fresh -> count 3 is remembered.
     _set_data_ok(coord, grades=True)
     assert sensor.state == 3
-    # Next poll: grades fail -> data_ok['grades'] = False, last_update_success True.
-    sensor._grades = []
+    # Next poll: grades fail -> coordinator data is empty AND data_ok False,
+    # with last_update_success still True (partial failure).
+    coord.data["grades"] = []
     _set_data_ok(coord, grades=False)
     # Not fresh: keep the last-known 3, marked stale, not reset to 0.
     assert sensor.state == 3
@@ -365,3 +396,39 @@ async def test_full_outage_still_makes_everything_stale(hass, coord):
     _outage(coord)
     assert sensor.data_stale is True
     assert sensor.available is True  # last-known value of 0 retained
+
+
+async def test_setup_uses_stored_student_when_first_refresh_fails(hass, coord):
+    """When EduPage is unavailable at startup, sensor setup must fall back to the
+    stored student id/name from the config entry so sensor construction does not
+    crash with a None name (which would skip RestoreEntity attachment)."""
+    from homeassistant.config_entries import ConfigEntry
+
+    # First refresh produced no student data at all.
+    coord.data = {}
+    coord.last_update_success = False
+
+    entry = ConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Edupage (Max)",
+        data={
+            "username": "u",
+            "subdomain": "s",
+            "phpsessid": "p",
+            CONF_STUDENT_ID: 42,
+            CONF_STUDENT_NAME: "Max Kov",
+        },
+        source="user",
+        entry_id="entry-fallback",
+    )
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coord
+
+    added = []
+    await async_setup_entry(hass, entry, added.append)
+
+    assert added, "expected at least the notification sensor to be created"
+    # Construction succeeded (no unidecode(None)); the stored name survives.
+    notif = added[0]
+    assert notif._student_id == 42
+    assert notif._student_name == "max_kov"

--- a/tests/test_restore_state.py
+++ b/tests/test_restore_state.py
@@ -369,6 +369,20 @@ async def test_grade_failure_marks_subject_stale(hass, coord):
     assert sensor.state == 4
 
 
+async def test_section_failure_makes_available_false_without_last_value(hass, coord):
+    """The overall coordinator update succeeds but this sensor's own section
+    failed and there is no restored/last-known value to fall back on: the sensor
+    must be unavailable (not report an invented 0 as available)."""
+    sensor = _subject_sensor(coord)
+    # No restored / last-known value.
+    assert sensor._last_value is None
+    # Coordinator globally up, but this sensor's section (grades) failed.
+    coord.last_update_success = True
+    _set_data_ok(coord, grades=False)
+    assert sensor.available is False
+
+
+
 async def test_notification_failure_independent_of_grades(hass, coord):
     """Grades may fail while notifications stay fresh; each sensor is independent."""
     grade_sensor = _subject_sensor(coord)

--- a/tests/test_restore_state.py
+++ b/tests/test_restore_state.py
@@ -301,3 +301,67 @@ async def test_empty_string_not_restored(hass, coord):
     _outage(coord)
     assert sensor._last_value is None
     assert sensor.available is False
+
+
+# ---------------------------------------------------------------------------
+# Partial coordinator failures: per-section freshness (#109 integration)
+# ---------------------------------------------------------------------------
+
+
+def _set_data_ok(coord, **sections):
+    """Seed the per-section freshness map on a coordinator."""
+    coord.data["data_ok"] = coord.data.get("data_ok", {}) or {}
+    coord.data["data_ok"].update(sections)
+
+
+async def test_grade_section_failure_keeps_last_value(hass, coord):
+    """When grades fail (#109) but the rest of the poll succeeds, the subject
+    sensor must not treat its data as fresh or reset to 0."""
+    sensor = EduPageSubjectSensor(coord, 1, "Max Kov", "Maths", [_Grade(1), _Grade(2), _Grade(3)])
+    # A good poll: grades fresh -> count 3 is remembered.
+    _set_data_ok(coord, grades=True)
+    assert sensor.state == 3
+    # Next poll: grades fail -> data_ok['grades'] = False, last_update_success True.
+    sensor._grades = []
+    _set_data_ok(coord, grades=False)
+    # Not fresh: keep the last-known 3, marked stale, not reset to 0.
+    assert sensor.state == 3
+    assert sensor.data_stale is True
+
+
+async def test_grade_failure_marks_subject_stale(hass, coord):
+    sensor = _subject_sensor(coord)
+    sensor._apply_restored(_FakeState("4"))
+    _set_data_ok(coord, grades=False)
+    # Whole coordinator is up but the grades section failed -> stale grade data.
+    assert sensor.data_stale is True
+    assert sensor.state == 4
+
+
+async def test_notification_failure_independent_of_grades(hass, coord):
+    """Grades may fail while notifications stay fresh; each sensor is independent."""
+    grade_sensor = _subject_sensor(coord)
+    notif_sensor = _notification_sensor(coord)
+
+    coord.data["grades"] = [_Grade(1)]
+    coord.data["notifications"] = [1, 2, 3]
+    _set_data_ok(coord, grades=False, notifications=True)
+
+    # Notifications fresh -> count 3, not stale.
+    assert notif_sensor.state == 3
+    assert notif_sensor.data_stale is False
+    # Grades failed -> not fresh, falls back to last-known (none here -> 0 path),
+    # but is marked stale.
+    assert grade_sensor.data_stale is True
+    assert grade_sensor.state == 0
+
+
+async def test_full_outage_still_makes_everything_stale(hass, coord):
+    """A complete coordinator outage keeps the whole-data fallback (no data_ok
+    needed) because last_update_success is False."""
+    sensor = _notification_sensor(coord)
+    assert sensor.state == 0
+    _set_data_ok(coord, notifications=True)
+    _outage(coord)
+    assert sensor.data_stale is True
+    assert sensor.available is True  # last-known value of 0 retained

--- a/tests/test_restore_state.py
+++ b/tests/test_restore_state.py
@@ -255,3 +255,49 @@ async def test_term_average_restored_as_float(hass, coord):
     _outage(coord)
     assert sensor.state == 2.5
     assert isinstance(sensor.state, float)
+
+
+# ---------------------------------------------------------------------------
+# Non-restorable states (unknown / unavailable / invalid) are ignored
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_state", ["unknown", "unavailable", "none", "abc", "not-a-number"]
+)
+async def test_unknown_unavailable_are_not_restored_as_real_values(
+    hass, coord, bad_state
+):
+    """Restoring 'unknown'/'unavailable'/invalid must not produce a value."""
+    sensor = _subject_sensor(coord)
+    sensor._apply_restored(_FakeState(bad_state))
+    _outage(coord)
+    # _last_value stays None -> not treated as available, no invented 0.
+    assert sensor._last_value is None
+    assert sensor.available is False
+
+
+async def test_unknown_restored_does_not_fake_grade_count(hass, coord):
+    """An 'unknown' grade count must not appear as a genuine zero."""
+    sensor = _subject_sensor(coord)
+    sensor._apply_restored(_FakeState("unknown"))
+    assert sensor._last_value is None
+    # Without fresh data and without a seeded value the sensor is unavailable.
+    _outage(coord)
+    assert sensor.available is False
+
+
+async def test_unknown_restored_for_term_average(hass, coord):
+    sensor = _term_sensor(coord)
+    sensor._apply_restored(_FakeState("unknown"))
+    _outage(coord)
+    assert sensor._last_value is None
+    assert sensor.available is False
+
+
+async def test_empty_string_not_restored(hass, coord):
+    sensor = _notification_sensor(coord)
+    sensor._apply_restored(_FakeState(""))
+    _outage(coord)
+    assert sensor._last_value is None
+    assert sensor.available is False


### PR DESCRIPTION
## What

Make the EduPage sensor states **survive Home Assistant restarts and coordinator outages**.

Today, when the coordinator is refreshing its data (e.g. right after a Home Assistant restart, or on the first successful poll after an EduPage API outage), the sensors report `0` / `unknown` instead of keeping their last-known value. This PR restores the previous state from the recorder and keeps showing it while there is no fresh data available.

## How

- Adds a `StateRestoringSensor` base class (`RestoreEntity`) that
  - restores the last state in `async_added_to_hass()`, and
  - falls back to that restored value whenever the coordinator has not yet completed a successful refresh.
- Applies it to all five sensor types:
  - `EduPageSubjectSensor`
  - `EduPageNotificationSensor`
  - `EduPageSubstitutionSensor`
  - `EduPageRingingSensor`
  - `EduPageTermAverageSensor`

The existing empty-data tolerance stays intact — the restored-state fallback is applied on top of it.

## Why

Without persistence, every HA restart or brief EduPage API outage resets dashboard/automation values (grade counts, substitution counts, averages, next ringing time) to a bogus `0`/`unknown` until the next poll.

## Related

Related to #94 (graceful handling when coordinator data is missing during initialization/outages) — this addresses the state-vanishes-on-restart/outage symptom rather than the setup-time init failure.
