### PR TITLE
chore: bump version to 0.5.3

### DIFF
--- a/custom_components/homeassistantedupage/manifest.json
+++ b/custom_components/homeassistantedupage/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/rine77/homeassistantedupage/issues",
     "requirements": ["edupage-api==0.12.5", "unidecode"],
-    "version": "0.5.2"
+    "version": "0.5.3"
 }


### PR DESCRIPTION
## Summary

Prepare the corrected v0.5.3 patch release.

The previously published `v0.5.2` tag accidentally pointed to the v0.5.1 commit and therefore did not include the fixes already merged into `main`.

This release contains the intended fixes for:

* missing student names
* empty meal data
* initialization failures caused by these conditions

## Changes

* Bump the integration version from `0.5.2` to `0.5.3`