### PR TITLE
fix: handle unavailable meal data quietly

### DIFF
--- a/custom_components/homeassistantedupage/homeassistant_edupage.py
+++ b/custom_components/homeassistantedupage/homeassistant_edupage.py
@@ -170,20 +170,17 @@ class Edupage:
 
     async def get_meals(self, day):
         try:
-            meals = await self.hass.async_add_executor_job(self.api.get_meals, day)
-            return meals
-        except IndexError:
-            _LOGGER.debug(
-                "EDUPAGE get_meals returned invalid/empty data for %s",
-                day,
+            return await self.hass.async_add_executor_job(
+                self.api.get_meals, day
             )
-            return None
-        except Exception as e:  # noqa: BLE001
-            _LOGGER.error(
-                "EDUPAGE error updating get_meals() data for %s: %s",
+        except (IndexError, AttributeError) as e:
+            _LOGGER.debug(
+                "EDUPAGE get_meals returned empty or unsupported data for %s: %s",
                 day,
                 e,
             )
+            return None
+        except Exception as e:  # noqa: BLE001
             raise UpdateFailed(
                 f"EDUPAGE error updating get_meals() data for {day}: {e}"
             ) from e

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -82,6 +82,7 @@ async def config_entry(hass):
         entry_id="test_entry",
         unique_id="test_unique_id",
         discovery_keys=set(),
+        subentries_data={},
         options={},
     )
     hass.data.setdefault(DOMAIN, {})

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from inspect import signature
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.core import HomeAssistant
 
@@ -82,7 +83,11 @@ async def config_entry(hass):
         entry_id="test_entry",
         unique_id="test_unique_id",
         discovery_keys=set(),
-        subentries_data={},
+        **(
+            {"subentries_data": {}}
+            if "subentries_data" in signature(config_entries.ConfigEntry).parameters
+            else {}
+        ),
         options={},
     )
     hass.data.setdefault(DOMAIN, {})

--- a/tests/test_edupage_wrapper.py
+++ b/tests/test_edupage_wrapper.py
@@ -12,7 +12,7 @@ homeassistantedupage#70 / #95:
 from unittest.mock import MagicMock, patch
 
 import pytest
-
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from custom_components.homeassistantedupage.homeassistant_edupage import (
     Edupage,
     EdupageSessionExpired,
@@ -71,3 +71,33 @@ async def test_login_returns_true_on_valid_session():
     ):
         result = await _wrapper(api).login("user", "mshviezdoslavova1", "sess")
     assert result is True
+
+async def test_get_meals_returns_none_on_index_error():
+    """Empty meal data represented by IndexError is treated as unavailable."""
+    api = MagicMock()
+    api.get_meals.side_effect = IndexError("list index out of range")
+
+    result = await _wrapper(api).get_meals("2026-09-04")
+
+    assert result is None
+
+
+async def test_get_meals_returns_none_on_attribute_error():
+    """Unsupported meal data represented by AttributeError is treated as unavailable."""
+    api = MagicMock()
+    api.get_meals.side_effect = AttributeError(
+        "'list' object has no attribute 'keys'"
+    )
+
+    result = await _wrapper(api).get_meals("2026-09-04")
+
+    assert result is None
+
+
+async def test_get_meals_raises_update_failed_on_unexpected_error():
+    """Unexpected meal API failures remain visible to the coordinator."""
+    api = MagicMock()
+    api.get_meals.side_effect = RuntimeError("connection failed")
+
+    with pytest.raises(UpdateFailed, match="connection failed"):
+        await _wrapper(api).get_meals("2026-09-04")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -40,7 +40,12 @@ class _FakeSubject:
 @pytest.fixture
 def coordinator(hass: HomeAssistant):
     """A coordinator whose data we can update to simulate polling."""
-    coord = DataUpdateCoordinator(hass, logging.getLogger("test"), name="test")
+    coord = DataUpdateCoordinator(
+        hass,
+        logging.getLogger("test"),
+        name="test",
+        config_entry=None,
+    )
     coord.data = {
         "student": {"id": 1, "name": "Max"},
         "notifications": [],


### PR DESCRIPTION
## Summary

Avoid repeated error and warning messages when a school does not provide meal data.

Some EduPage installations return empty or structurally unsupported meal responses, resulting in either an `IndexError` or an `AttributeError` such as:

```text
'list' object has no attribute 'keys'
```

These responses represent unavailable optional meal data and should not be treated as integration errors.

## Changes

* Treat `IndexError` and `AttributeError` from `get_meals()` as unavailable meal data
* Log these expected responses at debug level
* Return `None` so the coordinator can continue without meal entries
* Remove duplicate error logging for unexpected failures
* Continue propagating unexpected failures as `UpdateFailed`, which the coordinator logs once as a warning
* Add regression tests for empty, unsupported, and unexpected meal responses
* Update existing tests for the current Home Assistant test API

## Testing

```text
42 passed
```

Related to #104.
