### PR TITLE
chore: bump version to 0.5.4

### DIFF
--- a/custom_components/homeassistantedupage/manifest.json
+++ b/custom_components/homeassistantedupage/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/rine77/homeassistantedupage/issues",
     "requirements": ["edupage-api==0.12.5", "unidecode"],
-    "version": "0.5.3"
+    "version": "0.5.4"
 }


### PR DESCRIPTION
## Summary

Prepare the v0.5.4 patch release.

This release improves handling for EduPage installations where meal data is unavailable or returned in an unsupported empty format.

## Included fix

* Treat unavailable meal data as an optional missing feature
* Avoid repeated error and warning log entries for expected empty meal responses
* Keep unexpected API failures visible as a single warning
* Add regression tests for meal data handling
* Update tests for compatibility with current Home Assistant test APIs

Related to #104.
