### PR TITLE
fix: catch get_grades/subjects/notifications failures in coordinator

### DIFF
--- a/custom_components/homeassistantedupage/__init__.py
+++ b/custom_components/homeassistantedupage/__init__.py
@@ -75,9 +75,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     return {"timetable": {}}
 
                 student_name = student.name or stored_student_name or str(student.person_id)
-                grades = await edupage.get_grades()
-                subjects = await edupage.get_subjects()
-                notifications = await edupage.get_notifications()
+
+                try:
+                    grades = await edupage.get_grades()
+                except Exception as e:  # noqa: BLE001
+                    _LOGGER.warning("get_grades failed: %s", e)
+                    grades = []
+
+                try:
+                    subjects = await edupage.get_subjects()
+                except Exception as e:  # noqa: BLE001
+                    _LOGGER.warning("get_subjects failed: %s", e)
+                    subjects = []
+
+                try:
+                    notifications = await edupage.get_notifications()
+                except Exception as e:  # noqa: BLE001
+                    _LOGGER.warning("get_notifications failed: %s", e)
+                    notifications = []
 
                 today = datetime.now().date()
 

--- a/custom_components/homeassistantedupage/__init__.py
+++ b/custom_components/homeassistantedupage/__init__.py
@@ -27,6 +27,147 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     _LOGGER.debug("INIT called async_setup")
     return True
 
+
+async def _collect_data(edupage, student, student_name):
+    """Gather all EduPage data sections for a student.
+
+    Each optional data source is fetched independently. A failure in one
+    source (e.g. a ``get_grades()`` crash) must not discard the rest of the
+    data; the failed section falls back to an empty list so timetable,
+    calendar, meals and substitution data are still returned.
+    """
+    try:
+        grades = await edupage.get_grades()
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.warning("get_grades failed: %s", e)
+        grades = []
+
+    try:
+        subjects = await edupage.get_subjects()
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.warning("get_subjects failed: %s", e)
+        subjects = []
+
+    try:
+        notifications = await edupage.get_notifications()
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.warning("get_notifications failed: %s", e)
+        notifications = []
+
+    today = datetime.now().date()
+
+    timetable_data = {}
+    timetable_data_canceled = {}
+    for offset in range(14):
+        current_date = today + timedelta(days=offset)
+        try:
+            timetable = await edupage.get_timetable(
+                student, current_date
+            )
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to fetch timetable data for %s: %s",
+                current_date,
+                e,
+            )
+            break
+        lessons_to_add = []
+        canceled_lessons = []
+        if timetable is not None:
+            for lesson in timetable:
+                if not lesson.is_cancelled:
+                    lessons_to_add.append(lesson)
+                else:
+                    canceled_lessons.append(lesson)
+        if lessons_to_add:
+            timetable_data[current_date] = lessons_to_add
+        if canceled_lessons:
+            timetable_data_canceled[current_date] = canceled_lessons
+
+    canteen_menu_data = {}
+    for offset in range(14):
+        current_date = today + timedelta(days=offset)
+        try:
+            meals = await edupage.get_meals(current_date)
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning(
+                "Failed to fetch meals data for %s: %s",
+                current_date,
+                e,
+            )
+            continue
+        meals_to_add = []
+        if meals is not None:
+            for meal in (meals.snack, meals.lunch, meals.afternoon_snack):
+                if meal is not None and meal.menus:
+                    meals_to_add.append(meal)
+        if meals_to_add:
+            canteen_menu_data[current_date] = meals_to_add
+
+    # Substitution / ringing extras for sensors.
+    try:
+        timetable_changes = await edupage.get_timetable_changes(today)
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.warning(
+            "get_timetable_changes failed for %s: %s", today, e
+        )
+        timetable_changes = []
+
+    try:
+        missing_teachers = await edupage.get_missing_teachers(today)
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.warning(
+            "get_missing_teachers failed for %s: %s", today, e
+        )
+        missing_teachers = []
+
+    try:
+        next_ringing = await edupage.get_next_ringing_time(
+            datetime.now()
+        )
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.warning("get_next_ringing_time failed: %s", e)
+        next_ringing = None
+
+    # Per-term grades for grade-average sensors.
+    school_year = None
+    grades_per_term = {}
+    try:
+        school_year = await edupage.get_school_year()
+        term_map = {"first": Term.FIRST, "second": Term.SECOND}
+        for term_key, term_enum in term_map.items():
+            try:
+                grades_per_term[
+                    term_key
+                ] = await edupage.get_grades_for_term(
+                    school_year, term_enum
+                )
+            except Exception as e:  # noqa: BLE001
+                _LOGGER.warning(
+                    "get_grades_for_term(%s) failed: %s", term_key, e
+                )
+                grades_per_term[term_key] = []
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.warning("get_school_year failed: %s", e)
+        school_year = None
+
+    return {
+        "student": {"id": student.person_id, "name": student_name},
+        "grades": grades,
+        "subjects": subjects,
+        "timetable": timetable_data,
+        "canteen_menu": canteen_menu_data,
+        "cancelled_lessons": timetable_data_canceled,
+        "notifications": notifications,
+        "timetable_changes": timetable_changes,
+        "missing_teachers": missing_teachers,
+        "next_ringing": next_ringing,
+        "school_year": school_year,
+        "grades_per_term": grades_per_term,
+        "last_updated": datetime.now().isoformat(),
+    }
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up EduPage integration and validate the stored session."""
     if DOMAIN not in hass.data:
@@ -76,137 +217,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                 student_name = student.name or stored_student_name or str(student.person_id)
 
-                try:
-                    grades = await edupage.get_grades()
-                except Exception as e:  # noqa: BLE001
-                    _LOGGER.warning("get_grades failed: %s", e)
-                    grades = []
-
-                try:
-                    subjects = await edupage.get_subjects()
-                except Exception as e:  # noqa: BLE001
-                    _LOGGER.warning("get_subjects failed: %s", e)
-                    subjects = []
-
-                try:
-                    notifications = await edupage.get_notifications()
-                except Exception as e:  # noqa: BLE001
-                    _LOGGER.warning("get_notifications failed: %s", e)
-                    notifications = []
-
-                today = datetime.now().date()
-
-                timetable_data = {}
-                timetable_data_canceled = {}
-                for offset in range(14):
-                    current_date = today + timedelta(days=offset)
-                    try:
-                        timetable = await edupage.get_timetable(
-                            student, current_date
-                        )
-                    except Exception as e:  # noqa: BLE001
-                        _LOGGER.error(
-                            "Failed to fetch timetable data for %s: %s",
-                            current_date,
-                            e,
-                        )
-                        break
-                    lessons_to_add = []
-                    canceled_lessons = []
-                    if timetable is not None:
-                        for lesson in timetable:
-                            if not lesson.is_cancelled:
-                                lessons_to_add.append(lesson)
-                            else:
-                                canceled_lessons.append(lesson)
-                    if lessons_to_add:
-                        timetable_data[current_date] = lessons_to_add
-                    if canceled_lessons:
-                        timetable_data_canceled[current_date] = canceled_lessons
-
-                canteen_menu_data = {}
-                for offset in range(14):
-                    current_date = today + timedelta(days=offset)
-                    try:
-                        meals = await edupage.get_meals(current_date)
-                    except Exception as e:  # noqa: BLE001
-                        _LOGGER.warning(
-                            "Failed to fetch meals data for %s: %s",
-                            current_date,
-                            e,
-                        )
-                        continue
-                    meals_to_add = []
-                    if meals is not None:
-                        for meal in (meals.snack, meals.lunch, meals.afternoon_snack):
-                            if meal is not None and meal.menus:
-                                meals_to_add.append(meal)
-                    if meals_to_add:
-                        canteen_menu_data[current_date] = meals_to_add
-
-                # Substitution / ringing extras for sensors.
-                try:
-                    timetable_changes = await edupage.get_timetable_changes(today)
-                except Exception as e:  # noqa: BLE001
-                    _LOGGER.warning(
-                        "get_timetable_changes failed for %s: %s", today, e
-                    )
-                    timetable_changes = []
-
-                try:
-                    missing_teachers = await edupage.get_missing_teachers(today)
-                except Exception as e:  # noqa: BLE001
-                    _LOGGER.warning(
-                        "get_missing_teachers failed for %s: %s", today, e
-                    )
-                    missing_teachers = []
-
-                try:
-                    next_ringing = await edupage.get_next_ringing_time(
-                        datetime.now()
-                    )
-                except Exception as e:  # noqa: BLE001
-                    _LOGGER.warning("get_next_ringing_time failed: %s", e)
-                    next_ringing = None
-
-                # Per-term grades for grade-average sensors.
-                school_year = None
-                grades_per_term = {}
-                try:
-                    school_year = await edupage.get_school_year()
-                    term_map = {"first": Term.FIRST, "second": Term.SECOND}
-                    for term_key, term_enum in term_map.items():
-                        try:
-                            grades_per_term[
-                                term_key
-                            ] = await edupage.get_grades_for_term(
-                                school_year, term_enum
-                            )
-                        except Exception as e:  # noqa: BLE001
-                            _LOGGER.warning(
-                                "get_grades_for_term(%s) failed: %s", term_key, e
-                            )
-                            grades_per_term[term_key] = []
-                except Exception as e:  # noqa: BLE001
-                    _LOGGER.warning("get_school_year failed: %s", e)
-                    school_year = None
-
-                return_data = {
-                    "student": {"id": student.person_id, "name": student_name},
-                    "grades": grades,
-                    "subjects": subjects,
-                    "timetable": timetable_data,
-                    "canteen_menu": canteen_menu_data,
-                    "cancelled_lessons": timetable_data_canceled,
-                    "notifications": notifications,
-                    "timetable_changes": timetable_changes,
-                    "missing_teachers": missing_teachers,
-                    "next_ringing": next_ringing,
-                    "school_year": school_year,
-                    "grades_per_term": grades_per_term,
-                    "last_updated": datetime.now().isoformat(),
-                }
-                return return_data
+                return await _collect_data(edupage, student, student_name)
 
             except EdupageSessionExpired as e:
                 _LOGGER.error("INIT session expired during update: %s", e)

--- a/tests/test_edupage_wrapper.py
+++ b/tests/test_edupage_wrapper.py
@@ -72,6 +72,7 @@ async def test_login_returns_true_on_valid_session():
         result = await _wrapper(api).login("user", "mshviezdoslavova1", "sess")
     assert result is True
 
+
 async def test_get_meals_returns_none_on_index_error():
     """Empty meal data represented by IndexError is treated as unavailable."""
     api = MagicMock()
@@ -101,3 +102,29 @@ async def test_get_meals_raises_update_failed_on_unexpected_error():
 
     with pytest.raises(UpdateFailed, match="connection failed"):
         await _wrapper(api).get_meals("2026-09-04")
+
+
+# ---------------------------------------------------------------------------
+# Wrapper methods must surface API failures as UpdateFailed
+# ---------------------------------------------------------------------------
+
+
+async def test_get_grades_raises_update_failed_on_api_error():
+    api = MagicMock()
+    api.get_grades.side_effect = RuntimeError("non-numeric grade")
+    with pytest.raises(UpdateFailed, match="get_grades"):
+        await _wrapper(api).get_grades()
+
+
+async def test_get_subjects_raises_update_failed_on_api_error():
+    api = MagicMock()
+    api.get_subjects.side_effect = IndexError("empty subjects")
+    with pytest.raises(UpdateFailed, match="get_subjects"):
+        await _wrapper(api).get_subjects()
+
+
+async def test_get_notifications_raises_update_failed_on_api_error():
+    api = MagicMock()
+    api.get_notifications.side_effect = AttributeError("missing field")
+    with pytest.raises(UpdateFailed, match="get_notifications"):
+        await _wrapper(api).get_notifications()

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -19,7 +19,7 @@ from custom_components.homeassistantedupage.homeassistant_edupage import (
     UpdateFailed,
 )
 from custom_components.homeassistantedupage.sensor import _average, _grade_numeric
-from custom_components.homeassistantedupage import __init__ as init_module
+from custom_components.homeassistantedupage import _collect_data
 
 
 class _FakeHass:
@@ -255,7 +255,7 @@ async def test_collect_data_continues_when_get_grades_fails():
     edupage = _edupage_with_grades_failing()
     student = _OkStudent()
 
-    data = await init_module._collect_data(edupage, student, "Max")
+    data = await _collect_data(edupage, student, "Max")
 
     assert data["grades"] == []
     assert data["student"] == {"id": 1, "name": "Max"}
@@ -270,7 +270,7 @@ async def test_collect_data_continues_when_get_subjects_fails():
     edupage.get_grades = AsyncMock(return_value=[])
     edupage.get_subjects = AsyncMock(side_effect=IndexError("empty subjects"))
 
-    data = await init_module._collect_data(edupage, _OkStudent(), "Max")
+    data = await _collect_data(edupage, _OkStudent(), "Max")
 
     assert data["subjects"] == []
     assert data["grades"] == []
@@ -284,7 +284,7 @@ async def test_collect_data_continues_when_get_notifications_fails():
         side_effect=AttributeError("missing field")
     )
 
-    data = await init_module._collect_data(edupage, _OkStudent(), "Max")
+    data = await _collect_data(edupage, _OkStudent(), "Max")
 
     assert data["notifications"] == []
     assert data["student"]["name"] == "Max"
@@ -296,7 +296,7 @@ async def test_collect_data_preserves_student_when_only_grades_fail():
     edupage.get_timetable = AsyncMock(return_value=[])
     edupage.get_meals = AsyncMock(return_value=None)
 
-    data = await init_module._collect_data(edupage, _OkStudent(), "Max")
+    data = await _collect_data(edupage, _OkStudent(), "Max")
 
     assert data["student"] == {"id": 1, "name": "Max"}
     assert data["grades"] == []

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -9,7 +9,7 @@ the pytest-homeassistant-custom-component ``hass`` fixture.
 """
 
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -19,6 +19,7 @@ from custom_components.homeassistantedupage.homeassistant_edupage import (
     UpdateFailed,
 )
 from custom_components.homeassistantedupage.sensor import _average, _grade_numeric
+from custom_components.homeassistantedupage import __init__ as init_module
 
 
 class _FakeHass:
@@ -219,3 +220,85 @@ async def test_always_creates_canteen_calendar(hass: HomeAssistant):
     names = {type(e).__name__ for e in added}
     assert "EdupageCalendar" in names
     assert "EdupageCanteenCalendar" in names
+
+
+# ---------------------------------------------------------------------------
+# Coordinator-level: _collect_data fallback for failing data sections (#94/#93)
+# ---------------------------------------------------------------------------
+
+
+class _OkStudent:
+    """Minimal student object used by _collect_data."""
+
+    person_id = 1
+    name = "Max"
+
+
+def _edupage_with_grades_failing():
+    """An edupage whose get_grades() raises but everything else succeeds."""
+    edupage = MagicMock()
+    edupage.get_grades = AsyncMock(side_effect=RuntimeError("non-numeric grade"))
+    edupage.get_subjects = AsyncMock(return_value=["Math"])
+    edupage.get_notifications = AsyncMock(return_value=[{"id": 1}])
+    edupage.get_timetable = AsyncMock(return_value=[])
+    edupage.get_meals = AsyncMock(return_value=None)
+    edupage.get_timetable_changes = AsyncMock(return_value=[])
+    edupage.get_missing_teachers = AsyncMock(return_value=[])
+    edupage.get_next_ringing_time = AsyncMock(return_value=None)
+    edupage.get_school_year = AsyncMock(return_value=None)
+    edupage.get_grades_for_term = AsyncMock(return_value=[])
+    return edupage
+
+
+async def test_collect_data_continues_when_get_grades_fails():
+    """A get_grades() crash must not discard student/timetable/subjects data."""
+    edupage = _edupage_with_grades_failing()
+    student = _OkStudent()
+
+    data = await init_module._collect_data(edupage, student, "Max")
+
+    assert data["grades"] == []
+    assert data["student"] == {"id": 1, "name": "Max"}
+    assert data["subjects"] == ["Math"]
+    assert data["notifications"] == [{"id": 1}]
+    assert "timetable" in data
+    assert "canteen_menu" in data
+
+
+async def test_collect_data_continues_when_get_subjects_fails():
+    edupage = _edupage_with_grades_failing()
+    edupage.get_grades = AsyncMock(return_value=[])
+    edupage.get_subjects = AsyncMock(side_effect=IndexError("empty subjects"))
+
+    data = await init_module._collect_data(edupage, _OkStudent(), "Max")
+
+    assert data["subjects"] == []
+    assert data["grades"] == []
+
+
+async def test_collect_data_continues_when_get_notifications_fails():
+    edupage = _edupage_with_grades_failing()
+    edupage.get_grades = AsyncMock(return_value=[])
+    edupage.get_subjects = AsyncMock(return_value=[])
+    edupage.get_notifications = AsyncMock(
+        side_effect=AttributeError("missing field")
+    )
+
+    data = await init_module._collect_data(edupage, _OkStudent(), "Max")
+
+    assert data["notifications"] == []
+    assert data["student"]["name"] == "Max"
+
+
+async def test_collect_data_preserves_student_when_only_grades_fail():
+    """The reported #94 case: grades crash, everything else still loads."""
+    edupage = _edupage_with_grades_failing()
+    edupage.get_timetable = AsyncMock(return_value=[])
+    edupage.get_meals = AsyncMock(return_value=None)
+
+    data = await init_module._collect_data(edupage, _OkStudent(), "Max")
+
+    assert data["student"] == {"id": 1, "name": "Max"}
+    assert data["grades"] == []
+    assert isinstance(data["timetable"], dict)
+    assert isinstance(data["canteen_menu"], dict)


### PR DESCRIPTION
## Summary

**Scope clarification:** This PR mitigates the *cascading initialization failure* reported in #94 — it does **not** add support for verbal/non-numerical grades themselves. When `get_grades()` fails to parse non-numerical grades (a limitation in `edupage-api`), grade data will still be unavailable for affected users, but the rest of the integration now keeps working (student, timetable, calendar, meals, notifications, substitution data).

Previously, `get_grades()` was called with no guard in `fetch_data()`. On failure (e.g. non-numerical grades), the *entire* coordinator update failed and returned empty data — which cascaded into sensor setup failures (`student_name=None` → `unidecode()` `'NoneType' ... encode` crash) and empty timetables/calendars for all students (#93).

## Changes

- Extract the data-gathering body of `fetch_data()` into a module-level `_collect_data(edupage, student, student_name)` for testability (behavior unchanged)
- Inside `_collect_data`, wrap `get_grades()`, `get_subjects()`, `get_notifications()` in `try/except`, logging a warning and falling back to `[]` — matching the existing pattern already used for `get_timetable`, `get_meals`, `get_timetable_changes`, `get_missing_teachers`, and `get_next_ringing_time`
- A failure in one data section no longer discards the student or any other successfully loaded data

## Testing

- `tests/test_edupage_wrapper.py`: wrapper `get_grades`/`get_subjects`/`get_notifications` surface failures as `UpdateFailed`
- `tests/test_extras.py`: **coordinator-level tests** exercising `_collect_data` — a `get_grades()`/`get_subjects()`/`get_notifications()` crash still returns the student and all other data, with only the failed section falling back to `[]`

## Fixes

Fixes #94 — `get_grades()` crash cascading into init failure
Fixes #93 — second child's calendar empty (same root cause: `get_grades()` failure killed `fetch_data()` before the timetable loop)

## Related

PR #107 fixes `get_meals()` (same per-section pattern, already merged to main and rebased in).
