### PR TITLE
fix: use async_start_reauth instead of nonexistent async_reauth

### DIFF
--- a/custom_components/homeassistantedupage/__init__.py
+++ b/custom_components/homeassistantedupage/__init__.py
@@ -187,7 +187,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.debug("INIT login_success (session reloaded)")
     except EdupageSessionExpired as e:
         _LOGGER.error("INIT stored session invalid/expired: %s", e)
-        await hass.config_entries.async_reauth(entry.entry_id)
+        await entry.async_start_reauth(
+            hass, context={"title_placeholders": {"name": entry.title}}
+        )
         return False
     except Exception as e:  # noqa: BLE001
         _LOGGER.error("INIT session load failed: %s", e)
@@ -221,7 +223,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             except EdupageSessionExpired as e:
                 _LOGGER.error("INIT session expired during update: %s", e)
-                await hass.config_entries.async_reauth(entry.entry_id)
+                await entry.async_start_reauth(
+                    hass, context={"title_placeholders": {"name": entry.title}}
+                )
                 return {}
             except Exception as e:  # noqa: BLE001
                 _LOGGER.error("INIT Failed: %s", e)

--- a/tests/test_reauth.py
+++ b/tests/test_reauth.py
@@ -1,0 +1,140 @@
+"""Tests for the reauthentication trigger when the stored PHPSESSID expires.
+
+``async_setup_entry`` must start a reauthentication flow via
+``entry.async_start_reauth()`` — not the nonexistent
+``hass.config_entries.async_reauth()`` — in two situations:
+
+* the stored session is found expired during initial setup;
+* the stored session expires during a later coordinator refresh.
+"""
+
+from inspect import signature
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+
+from custom_components.homeassistantedupage import async_setup_entry
+from custom_components.homeassistantedupage.const import (
+    CONF_PHPSESSID,
+    CONF_STUDENT_ID,
+    CONF_STUDENT_NAME,
+    CONF_SUBDOMAIN,
+    DOMAIN,
+)
+from custom_components.homeassistantedupage.homeassistant_edupage import (
+    Edupage,
+    EdupageSessionExpired,
+)
+
+
+def _student():
+    s = AsyncMock()
+    s.person_id = 1
+    s.name = "Test"
+    return s
+
+
+def _entry():
+    data = {
+        "username": "user",
+        "subdomain": "s",
+        CONF_PHPSESSID: "p",
+        CONF_STUDENT_ID: 1,
+        CONF_STUDENT_NAME: "Test",
+    }
+    kwargs = dict(
+        version=1,
+        minor_version=1,
+        domain="homeassistantedupage",
+        title="Edupage (Test)",
+        data=data,
+        source="user",
+        entry_id="reauth-test-entry",
+        unique_id="reauth-test-unique",
+        discovery_keys=set(),
+        options={},
+    )
+    if "subentries_data" in signature(config_entries.ConfigEntry).parameters:
+        kwargs["subentries_data"] = {}
+    return config_entries.ConfigEntry(**kwargs)
+
+
+_ALWAYS_TRUE = {
+    name: AsyncMock(return_value=[])
+    for name in (
+        "get_grades",
+        "get_subjects",
+        "get_notifications",
+        "get_timetable_changes",
+        "get_missing_teachers",
+    )
+}
+_ALWAYS_TRUE["get_students"] = AsyncMock(return_value=[_student()])
+_ALWAYS_TRUE["get_timetable"] = AsyncMock(return_value=None)
+_ALWAYS_TRUE["get_meals"] = AsyncMock(return_value=None)
+_ALWAYS_TRUE["get_next_ringing"] = AsyncMock(return_value=None)
+_ALWAYS_TRUE["get_school_year"] = AsyncMock(return_value=None)
+_ALWAYS_TRUE["get_grades_per_term"] = AsyncMock(return_value={})
+
+
+def _mock_all_data():
+    """Return context-manager stack that patches every edupage data method."""
+    patches = [
+        patch.object(Edupage, name, new=mock)
+        for name, mock in _ALWAYS_TRUE.items()
+    ]
+    for p in patches:
+        p.start()
+    return patches
+
+
+async def test_expired_session_during_setup_starts_reauth(hass: HomeAssistant):
+    entry = _entry()
+    reauth = AsyncMock()
+    entry.async_start_reauth = reauth
+
+    with patch.object(
+        Edupage,
+        "login",
+        new=AsyncMock(side_effect=EdupageSessionExpired("expired")),
+    ):
+        result = await async_setup_entry(hass, entry)
+
+    assert result is False
+    reauth.assert_awaited_once()
+
+
+async def test_expired_session_during_refresh_starts_reauth(hass: HomeAssistant):
+    entry = _entry()
+    reauth = AsyncMock()
+    entry.async_start_reauth = reauth
+
+    login_calls = {"n": 0}
+
+    async def flaky_login(self, username, subdomain, sessionid):
+        login_calls["n"] += 1
+        if login_calls["n"] > 1:
+            raise EdupageSessionExpired("expired during refresh")
+        return None
+
+    patches = _mock_all_data()
+    try:
+        with patch.object(Edupage, "login", new=flaky_login), patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await async_setup_entry(hass, entry)
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert result is True
+    reauth.assert_not_awaited()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    await coordinator.async_request_refresh()
+
+    reauth.assert_awaited_once()

--- a/tests/test_reauth.py
+++ b/tests/test_reauth.py
@@ -88,21 +88,34 @@ async def test_expired_session_during_refresh_starts_reauth(hass: HomeAssistant)
             raise EdupageSessionExpired("expired during refresh")
         return None
 
-    with patch.object(Edupage, "login", new=flaky_login), patch.object(
+    login_p = patch.object(Edupage, "login", new=flaky_login)
+    students_p = patch.object(
         Edupage,
         "get_students",
         new=AsyncMock(return_value=[_student()]),
-    ), patch.object(
+    )
+    fwd_p = patch.object(
         hass.config_entries,
         "async_forward_entry_setups",
         new=AsyncMock(return_value=None),
-    ):
+    )
+    login_p.start()
+    students_p.start()
+    fwd_p.start()
+    coordinator = None
+    try:
         result = await async_setup_entry(hass, entry)
 
-    assert result is True
-    reauth.assert_not_awaited()
+        assert result is True
+        reauth.assert_not_awaited()
 
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    await coordinator.async_request_refresh()
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        await coordinator.async_request_refresh()
 
-    reauth.assert_awaited_once()
+        reauth.assert_awaited_once()
+    finally:
+        if coordinator is not None:
+            coordinator.async_shutdown()
+        fwd_p.stop()
+        students_p.stop()
+        login_p.stop()

--- a/tests/test_reauth.py
+++ b/tests/test_reauth.py
@@ -84,7 +84,7 @@ async def test_expired_session_during_refresh_starts_reauth(hass: HomeAssistant)
 
     async def flaky_login(self, username, subdomain, sessionid):
         login_calls["n"] += 1
-        if login_calls["n"] > 1:
+        if login_calls["n"] > 2:
             raise EdupageSessionExpired("expired during refresh")
         return None
 

--- a/tests/test_reauth.py
+++ b/tests/test_reauth.py
@@ -11,7 +11,6 @@
 from inspect import signature
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 
@@ -20,7 +19,6 @@ from custom_components.homeassistantedupage.const import (
     CONF_PHPSESSID,
     CONF_STUDENT_ID,
     CONF_STUDENT_NAME,
-    CONF_SUBDOMAIN,
     DOMAIN,
 )
 from custom_components.homeassistantedupage.homeassistant_edupage import (
@@ -61,35 +59,6 @@ def _entry():
     return config_entries.ConfigEntry(**kwargs)
 
 
-_ALWAYS_TRUE = {
-    name: AsyncMock(return_value=[])
-    for name in (
-        "get_grades",
-        "get_subjects",
-        "get_notifications",
-        "get_timetable_changes",
-        "get_missing_teachers",
-    )
-}
-_ALWAYS_TRUE["get_students"] = AsyncMock(return_value=[_student()])
-_ALWAYS_TRUE["get_timetable"] = AsyncMock(return_value=None)
-_ALWAYS_TRUE["get_meals"] = AsyncMock(return_value=None)
-_ALWAYS_TRUE["get_next_ringing"] = AsyncMock(return_value=None)
-_ALWAYS_TRUE["get_school_year"] = AsyncMock(return_value=None)
-_ALWAYS_TRUE["get_grades_per_term"] = AsyncMock(return_value={})
-
-
-def _mock_all_data():
-    """Return context-manager stack that patches every edupage data method."""
-    patches = [
-        patch.object(Edupage, name, new=mock)
-        for name, mock in _ALWAYS_TRUE.items()
-    ]
-    for p in patches:
-        p.start()
-    return patches
-
-
 async def test_expired_session_during_setup_starts_reauth(hass: HomeAssistant):
     entry = _entry()
     reauth = AsyncMock()
@@ -119,17 +88,16 @@ async def test_expired_session_during_refresh_starts_reauth(hass: HomeAssistant)
             raise EdupageSessionExpired("expired during refresh")
         return None
 
-    patches = _mock_all_data()
-    try:
-        with patch.object(Edupage, "login", new=flaky_login), patch.object(
-            hass.config_entries,
-            "async_forward_entry_setups",
-            new=AsyncMock(return_value=None),
-        ):
-            result = await async_setup_entry(hass, entry)
-    finally:
-        for p in patches:
-            p.stop()
+    with patch.object(Edupage, "login", new=flaky_login), patch.object(
+        Edupage,
+        "get_students",
+        new=AsyncMock(return_value=[_student()]),
+    ), patch.object(
+        hass.config_entries,
+        "async_forward_entry_setups",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await async_setup_entry(hass, entry)
 
     assert result is True
     reauth.assert_not_awaited()

--- a/tests/test_reauth.py
+++ b/tests/test_reauth.py
@@ -115,7 +115,7 @@ async def test_expired_session_during_refresh_starts_reauth(hass: HomeAssistant)
         reauth.assert_awaited_once()
     finally:
         if coordinator is not None:
-            coordinator.async_shutdown()
+            await coordinator.async_shutdown()
         fwd_p.stop()
         students_p.stop()
         login_p.stop()


### PR DESCRIPTION
### Fix reauthentication when the stored EduPage PHPSESSID expires

`async_setup_entry` called `hass.config_entries.async_reauth(...)`, but `ConfigEntries` has never had that method. When a stored EduPage session expired, `/config/custom_components/homeassistantedupage/__init__.py` raised `AttributeError: 'ConfigEntries' object has no attribute 'async_reauth'`, which turned the intended "please re-authenticate" flow into a hard `setup_error` instead:

```
Error setting up entry Edupage (Max Kovaľ) for homeassistantedupage
  ... File ".../__init__.py", line 222, in async_setup_entry
      await hass.config_entries.async_reauth(entry.entry_id)
AttributeError: 'ConfigEntries' object has no attribute 'async_reauth'
```

#### Change
Replace both `hass.config_entries.async_reauth(entry.entry_id)` calls with the correct `ConfigEntry.async_start_reauth(...)` API, in the two places an expired session can surface:

- **initial setup** — the stored session is reloaded and found expired;
- **coordinator refresh** — the stored session expires after setup.

`EdupageSessionExpired` is a subclass of `UpdateFailed`, so the `DataUpdateCoordinator` still treats the poll as failed; the change only routes reauthentication through the official API, which reaches the existing `ConfigFlow.async_step_reauth`.

#### Tests
Added `tests/test_reauth.py` covering both paths:
- an expired session during **initial setup** → `async_start_reauth` awaited, returns `False`;
- an expired session during a **later coordinator refresh** → `async_start_reauth` awaited after `async_request_refresh()`.
