### PR TITLE
chore: prepare release 0.5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The integration is based on the [edupage-api](https://github.com/EdupageAPI/edup
 - Modern app-code two-factor authentication
 - Interactive reauthentication when a stored session expires
 - English, German, and Slovak translations
+- Restoration of the last known sensor states after Home Assistant restarts or temporary EduPage outages
 
 ## Installation
 

--- a/custom_components/homeassistantedupage/__init__.py
+++ b/custom_components/homeassistantedupage/__init__.py
@@ -269,6 +269,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         name="Edupage",
         update_method=fetch_data,
         update_interval=timedelta(minutes=30),
+        config_entry=entry,
     )
     coordinator.edupage = edupage
     coordinator.fetch_lock = fetch_lock

--- a/custom_components/homeassistantedupage/manifest.json
+++ b/custom_components/homeassistantedupage/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/rine77/homeassistantedupage/issues",
     "requirements": ["edupage-api==0.12.5", "unidecode"],
-    "version": "0.5.4"
+    "version": "0.5.5"
 }

--- a/tests/test_reauth.py
+++ b/tests/test_reauth.py
@@ -77,6 +77,11 @@ async def test_expired_session_during_setup_starts_reauth(hass: HomeAssistant):
 
 async def test_expired_session_during_refresh_starts_reauth(hass: HomeAssistant):
     entry = _entry()
+    entry._async_set_state(
+        hass,
+        config_entries.ConfigEntryState.SETUP_IN_PROGRESS,
+        None,
+    )
     reauth = AsyncMock()
     entry.async_start_reauth = reauth
 

--- a/tests/test_restore_state.py
+++ b/tests/test_restore_state.py
@@ -23,6 +23,10 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from inspect import signature
+
+from homeassistant import config_entries
+
 from custom_components.homeassistantedupage.const import (
     CONF_STUDENT_ID,
     CONF_STUDENT_NAME,
@@ -65,7 +69,32 @@ class _Ringing:
 @pytest.fixture
 def coord(hass: HomeAssistant):
     """A coordinator whose data and freshness we control directly."""
-    c = DataUpdateCoordinator(hass, logging.getLogger("test"), name="test")
+    entry_kwargs = {
+        "version": 1,
+        "minor_version": 1,
+        "domain": DOMAIN,
+        "title": "EduPage test entry",
+        "data": {
+            CONF_STUDENT_ID: 1,
+            CONF_STUDENT_NAME: "Max",
+        },
+        "source": "user",
+        "entry_id": "restore-state-test-entry",
+        "unique_id": "restore-state-test-unique",
+        "discovery_keys": set(),
+        "options": {},
+    }
+    if "subentries_data" in signature(config_entries.ConfigEntry).parameters:
+        entry_kwargs["subentries_data"] = {}
+
+    entry = config_entries.ConfigEntry(**entry_kwargs)
+
+    c = DataUpdateCoordinator(
+        hass,
+        logging.getLogger("test"),
+        name="test",
+        config_entry=entry,
+    )
     c.data = {
         "student": {"id": 1, "name": "Max"},
         "subjects": [],
@@ -438,6 +467,11 @@ async def test_setup_uses_stored_student_when_first_refresh_fails(hass, coord):
         entry_id="entry-fallback",
         unique_id="unique-fallback",
         discovery_keys=set(),
+        **(
+            {"subentries_data": {}}
+            if "subentries_data" in signature(ConfigEntry).parameters
+            else {}
+        ),
         options={},
     )
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coord


### PR DESCRIPTION
## Summary

This PR prepares the 0.5.5 release.

* bumps the integration version from 0.5.4 to 0.5.5
* documents restoration of the last known sensor states after Home Assistant restarts or temporary EduPage outages
* passes the config entry explicitly to the `DataUpdateCoordinator` for compatibility with current Home Assistant versions
* updates the reauthentication and restore-state tests for both current and older Home Assistant test APIs

## Validation

* full test suite passes: **82 passed**
* `git diff --check` passes
* tested locally with Python 3.14 and the current `pytest-homeassistant-custom-component`
