### PR TITLE
feat: expose latest grade attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ grade_1_teacher: Example Teacher
 
 Depending on the information supplied by the school, attributes may also include maximum points, percentages, class averages, and teacher comments.
 
+For convenient access to the most recent grade, each subject sensor also exposes the following attributes:
+
+- `latest_grade`
+- `latest_grade_title`
+- `latest_grade_date`
+- `latest_grade_teacher`
+- `latest_grade_comment`
+- `latest_grade_percent`
+- `latest_grade_max_points`
+- `latest_grade_class_avg_grade`
+
+The latest grade is determined by its date rather than by the order returned by EduPage. Optional attributes are omitted when the corresponding information is not provided by the school.
+
 Inspect the sensor under **Developer tools → States** to see its actual entity ID and attributes.
 
 Example template:

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -281,6 +281,48 @@ class EduPageSubjectSensor(StateRestoringSensor):
                 teacher_name = grade.teacher.name if grade.teacher else "unknown"
                 attributes[f"grade_{i+1}_teacher"] = teacher_name
 
+            dated_grades = [
+                grade
+                for grade in current_grades
+                if getattr(grade, "date", None) is not None
+            ]
+            latest_grade = (
+                max(dated_grades, key=lambda grade: grade.date)
+                if dated_grades
+                else current_grades[-1]
+            )
+
+            attributes["latest_grade"] = latest_grade.grade_n
+            attributes["latest_grade_title"] = latest_grade.title
+
+            latest_date = getattr(latest_grade, "date", None)
+            if latest_date is not None:
+                attributes["latest_grade_date"] = latest_date.strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
+
+            latest_teacher = getattr(latest_grade, "teacher", None)
+            latest_teacher_name = getattr(latest_teacher, "name", None)
+            if latest_teacher_name:
+                attributes["latest_grade_teacher"] = latest_teacher_name
+
+            optional_latest_attributes = {
+                "latest_grade_comment": getattr(latest_grade, "comment", None),
+                "latest_grade_percent": getattr(latest_grade, "percent", None),
+                "latest_grade_max_points": getattr(
+                    latest_grade, "max_points", None
+                ),
+                "latest_grade_class_avg_grade": getattr(
+                    latest_grade, "class_grade_avg", None
+                ),
+            }
+            attributes.update(
+                {
+                    key: value
+                    for key, value in optional_latest_attributes.items()
+                    if value is not None
+                }
+            )
         attributes["data_stale"] = self.data_stale
         return attributes
 

--- a/custom_components/homeassistantedupage/sensor.py
+++ b/custom_components/homeassistantedupage/sensor.py
@@ -281,17 +281,10 @@ class EduPageSubjectSensor(StateRestoringSensor):
                 teacher_name = grade.teacher.name if grade.teacher else "unknown"
                 attributes[f"grade_{i+1}_teacher"] = teacher_name
 
-            dated_grades = [
-                grade
-                for grade in current_grades
-                if getattr(grade, "date", None) is not None
-            ]
-            latest_grade = (
-                max(dated_grades, key=lambda grade: grade.date)
-                if dated_grades
-                else current_grades[-1]
+            latest_grade = max(
+                current_grades,
+                key=lambda grade: grade.date,
             )
-
             attributes["latest_grade"] = latest_grade.grade_n
             attributes["latest_grade_title"] = latest_grade.title
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -216,7 +216,7 @@ def test_latest_grade_omits_missing_optional_fields(coordinator):
         _FakeGrade(
             3,
             "Short test",
-            None,
+            datetime(2026, 9, 2, 9, 0),
         )
     ]
 
@@ -233,7 +233,7 @@ def test_latest_grade_omits_missing_optional_fields(coordinator):
 
     assert attrs["latest_grade"] == 3
     assert attrs["latest_grade_title"] == "Short test"
-    assert "latest_grade_date" not in attrs
+    assert attrs["latest_grade_date"] == "2026-09-02 09:00:00"
     assert "latest_grade_teacher" not in attrs
     assert "latest_grade_comment" not in attrs
     assert "latest_grade_percent" not in attrs

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -17,7 +17,11 @@ from custom_components.homeassistantedupage.sensor import (
     EduPageNotificationSensor,
 )
 from custom_components.homeassistantedupage import sensor as sensor_module
-
+from custom_components.homeassistantedupage.sensor import (
+    _MAX_EVENTS,
+    EduPageNotificationSensor,
+    EduPageSubjectSensor,
+)
 
 class _FakeEvent:
     """Minimal notification event with the fields the sensor reads."""
@@ -36,6 +40,31 @@ class _FakeSubject:
         self.subject_id = subject_id
         self.name = name
 
+class _FakeGrade:
+    """Minimal grade object with the fields used by the subject sensor."""
+
+    def __init__(
+            self,
+            grade_n,
+            title,
+            date,
+            *,
+            teacher=None,
+            comment=None,
+            percent=None,
+            max_points=None,
+            class_grade_avg=None,
+            subject_id=1,
+    ):
+        self.grade_n = grade_n
+        self.title = title
+        self.date = date
+        self.teacher = teacher
+        self.comment = comment
+        self.percent = percent
+        self.max_points = max_points
+        self.class_grade_avg = class_grade_avg
+        self.subject_id = subject_id
 
 @pytest.fixture
 def coordinator(hass: HomeAssistant):
@@ -143,3 +172,74 @@ async def test_flat_event_attributes_are_bounded(hass, coordinator):
     # Only the first _MAX_EVENTS events are emitted as flat attributes.
     assert attrs[f"event_{_MAX_EVENTS}_id"] == _MAX_EVENTS - 1
     assert f"event_{_MAX_EVENTS + 1}_id" not in attrs
+
+def test_latest_grade_uses_date_not_api_order(coordinator):
+    """The latest grade must be selected by date from an unsorted API result."""
+    older = _FakeGrade(
+        2,
+        "Older test",
+        datetime(2026, 8, 20, 8, 0),
+        teacher=_FakeSubject(10, "Mrs Older"),
+    )
+    latest = _FakeGrade(
+        1,
+        "Latest test",
+        datetime(2026, 9, 3, 10, 30),
+        teacher=_FakeSubject(11, "Mr Latest"),
+        comment="Excellent",
+        percent=95,
+        max_points=20,
+        class_grade_avg=2.4,
+    )
+    coordinator.data["grades"] = [latest, older]
+
+    sensor = EduPageSubjectSensor(
+        coordinator,
+        student_id=1,
+        student_name="Max Kovaľ",
+        subject_name="Maths",
+        subject_id=1,
+        grades=[],
+    )
+
+    attrs = sensor.extra_state_attributes
+
+    assert attrs["latest_grade"] == 1
+    assert attrs["latest_grade_title"] == "Latest test"
+    assert attrs["latest_grade_date"] == "2026-09-03 10:30:00"
+    assert attrs["latest_grade_teacher"] == "Mr Latest"
+    assert attrs["latest_grade_comment"] == "Excellent"
+    assert attrs["latest_grade_percent"] == 95
+    assert attrs["latest_grade_max_points"] == 20
+    assert attrs["latest_grade_class_avg_grade"] == 2.4
+
+
+def test_latest_grade_omits_missing_optional_fields(coordinator):
+    """Optional latest-grade attributes are omitted when EduPage has no value."""
+    coordinator.data["grades"] = [
+        _FakeGrade(
+            3,
+            "Short test",
+            datetime(2026, 9, 2, 9, 0),
+        )
+    ]
+
+    sensor = EduPageSubjectSensor(
+        coordinator,
+        student_id=1,
+        student_name="Max Kovaľ",
+        subject_name="Maths",
+        subject_id=1,
+        grades=[],
+    )
+
+    attrs = sensor.extra_state_attributes
+
+    assert attrs["latest_grade"] == 3
+    assert attrs["latest_grade_title"] == "Short test"
+    assert attrs["latest_grade_date"] == "2026-09-02 09:00:00"
+    assert "latest_grade_teacher" not in attrs
+    assert "latest_grade_comment" not in attrs
+    assert "latest_grade_percent" not in attrs
+    assert "latest_grade_max_points" not in attrs
+    assert "latest_grade_class_avg_grade" not in attrs

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,10 +12,6 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from custom_components.homeassistantedupage.sensor import (
-    _MAX_EVENTS,
-    EduPageNotificationSensor,
-)
 from custom_components.homeassistantedupage import sensor as sensor_module
 from custom_components.homeassistantedupage.sensor import (
     _MAX_EVENTS,
@@ -220,7 +216,7 @@ def test_latest_grade_omits_missing_optional_fields(coordinator):
         _FakeGrade(
             3,
             "Short test",
-            datetime(2026, 9, 2, 9, 0),
+            None,
         )
     ]
 
@@ -237,7 +233,7 @@ def test_latest_grade_omits_missing_optional_fields(coordinator):
 
     assert attrs["latest_grade"] == 3
     assert attrs["latest_grade_title"] == "Short test"
-    assert attrs["latest_grade_date"] == "2026-09-02 09:00:00"
+    assert "latest_grade_date" not in attrs
     assert "latest_grade_teacher" not in attrs
     assert "latest_grade_comment" not in attrs
     assert "latest_grade_percent" not in attrs


### PR DESCRIPTION
## Summary

- expose the most recent grade directly on each subject sensor
- determine the latest grade by date instead of relying on API order
- include available title, date, teacher, comment, percentage, maximum-points, and class-average metadata
- omit optional attributes when EduPage does not provide the corresponding value
- document the new attributes in the README

## Validation

- full test suite passes: **84 passed**
- tests cover unsorted grade data and missing optional fields
- `git diff --check` passes

Closes #74