### PR TITLE
chore: bump version to 0.5.6

### DIFF
--- a/custom_components/homeassistantedupage/manifest.json
+++ b/custom_components/homeassistantedupage/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/rine77/homeassistantedupage/issues",
     "requirements": ["edupage-api==0.12.5", "unidecode"],
-    "version": "0.5.5"
+    "version": "0.5.6"
 }


### PR DESCRIPTION
## Summary

- bump the integration version from 0.5.5 to 0.5.6
- release the new convenient latest-grade attributes added in #112
- README documentation was updated as part of #112

## Validation

- full test suite passes: **84 passed**
- `git diff --check` passes